### PR TITLE
fix buildroot crosscompile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ set (CMAKE CXX_FLAGS "-Wall -Wextra -pedantic -Wno-unused-parameter -faligned-ne
 add_definitions(-Wfatal-errors)
 add_definitions(-Wno-psabi)
 add_definitions(-DBOOST_LOG_DYN_LINK)
-add_definitions(-mfpu=neon-fp-armv8 -ftree-vectorize)
+
+IF (NOT ENABLE_COMPILE_FLAGS_FOR_TARGET)
+  set(ENABLE_COMPILE_FLAGS_FOR_TARGET "armv8")
+endif()
+if ("${ENABLE_COMPILE_FLAGS_FOR_TARGET}" STREQUAL "armv8")
+  add_definitions(-mfpu=neon-fp-armv8 -ftree-vectorize)
+endif()
 
 project(common)
 add_library(common output.cpp file_output.cpp net_output.cpp circular_output.cpp egl_preview.cpp drm_preview.cpp jpeg.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,31 +50,28 @@ message(STATUS "${EPOXY_LIBRARY}")
 find_library(DRM_LIBRARY libdrm.so REQUIRED)
 message(STATUS "${DRM_LIBRARY}")
 
-find_library(IPA_RPI_LIBRARY ipa_rpi.so PATHS "${CAMERA_LIBRARY_DIRS}/libcamera" REQUIRED)
-message(STATUS "${IPA_RPI_LIBRARY}")
-
 add_executable(libcamera-still libcamera_still.cpp yuv.cpp dng.cpp png.cpp bmp.cpp)
-target_link_libraries(libcamera-still common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif ${Boost_LIBRARIES} jpeg tiff png pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-still common "${LIBCAMERA_LIBRARY}" exif ${Boost_LIBRARIES} jpeg tiff png pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-vid)
 
 add_executable(libcamera-vid libcamera_vid.cpp)
-target_link_libraries(libcamera-vid encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif ${Boost_LIBRARIES} pthread jpeg "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-vid encoders common "${LIBCAMERA_LIBRARY}" exif ${Boost_LIBRARIES} pthread jpeg "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-hello)
 
 add_executable(libcamera-hello libcamera_hello.cpp)
-target_link_libraries(libcamera-hello common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif ${Boost_LIBRARIES} jpeg pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-hello common "${LIBCAMERA_LIBRARY}" exif ${Boost_LIBRARIES} jpeg pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-raw)
 
 add_executable(libcamera-raw libcamera_raw.cpp)
-target_link_libraries(libcamera-raw encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-raw encoders common "${LIBCAMERA_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-jpeg)
 
 add_executable(libcamera-jpeg libcamera_jpeg.cpp)
-target_link_libraries(libcamera-jpeg common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-jpeg common "${LIBCAMERA_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 install(TARGETS common encoders LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 install(TARGETS libcamera-still libcamera-vid libcamera-hello libcamera-raw libcamera-jpeg RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,9 @@ project(libcamera-still)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CAMERA REQUIRED camera)
+pkg_check_modules(LIBDRM REQUIRED libdrm)
 
-include_directories(. "${CAMERA_INCLUDE_DIRS}" /usr/include/libdrm)
+include_directories(. "${CAMERA_INCLUDE_DIRS}" "${LIBDRM_INCLUDE_DIRS}")
 
 find_package( Boost REQUIRED COMPONENTS program_options )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,3 +75,6 @@ project(libcamera-jpeg)
 
 add_executable(libcamera-jpeg libcamera_jpeg.cpp)
 target_link_libraries(libcamera-jpeg common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+
+install(TARGETS common encoders LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+install(TARGETS libcamera-still libcamera-vid libcamera-hello libcamera-raw libcamera-jpeg RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,17 +59,17 @@ target_link_libraries(libcamera-still common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_L
 project(libcamera-vid)
 
 add_executable(libcamera-vid libcamera_vid.cpp)
-target_link_libraries(libcamera-vid encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" ${Boost_LIBRARIES} pthread jpeg "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-vid encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif ${Boost_LIBRARIES} pthread jpeg "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-hello)
 
 add_executable(libcamera-hello libcamera_hello.cpp)
-target_link_libraries(libcamera-hello common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-hello common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif ${Boost_LIBRARIES} jpeg pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-raw)
 
 add_executable(libcamera-raw libcamera_raw.cpp)
-target_link_libraries(libcamera-raw encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
+target_link_libraries(libcamera-raw encoders common "${LIBCAMERA_LIBRARY}" "${IPA_RPI_LIBRARY}" exif jpeg ${Boost_LIBRARIES} pthread "${X11_LIBRARIES}" "${EPOXY_LIBRARY}" "${DRM_LIBRARY}")
 
 project(libcamera-jpeg)
 

--- a/circular_output.cpp
+++ b/circular_output.cpp
@@ -69,7 +69,7 @@ void CircularOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, 
 		cb_.Read([&dst](void *src, int n) { memcpy(dst, src, n); dst += n; }, sizeof(header));
 		cb_.Skip((header.length + ALIGN - 1) & ~(ALIGN - 1));
 	}
-	Header header = { size, flags & FLAG_KEYFRAME, timestamp_us };
+	Header header = { static_cast<unsigned int>(size), flags & FLAG_KEYFRAME, timestamp_us };
 	cb_.Write(&header, sizeof(header));
 	cb_.Write(mem, size);
 	cb_.Pad(pad);

--- a/egl_preview.cpp
+++ b/egl_preview.cpp
@@ -216,7 +216,8 @@ void EglPreview::makeWindow(char const *name)
 	if (!eglGetConfigAttrib(egl_display_, config, EGL_NATIVE_VISUAL_ID, &vid))
 		throw std::runtime_error("eglGetConfigAttrib() failed\n");
 
-	XVisualInfo visTemplate = { .visualid = (long unsigned int)vid };
+	XVisualInfo visTemplate = {};
+	visTemplate.visualid = (VisualID)vid;
 	int num_visuals;
 	XVisualInfo *visinfo = XGetVisualInfo(display_, VisualIDMask,
                                          &visTemplate, &num_visuals);

--- a/jpeg.cpp
+++ b/jpeg.cpp
@@ -325,7 +325,7 @@ static void YUV420_to_JPEG_fast(const uint8_t *input,
 	cinfo.restart_interval = restart;
 
     jpeg_set_defaults(&cinfo);
-	cinfo.raw_data_in = true;
+	cinfo.raw_data_in = TRUE;
     jpeg_set_quality(&cinfo, quality, TRUE);
 	jpeg_buffer = NULL;
 	jpeg_len = 0;

--- a/libcamera_app.hpp
+++ b/libcamera_app.hpp
@@ -328,7 +328,7 @@ public:
 		if (!controls_.contains(controls::FrameDurations))
 		{
 			if (still_stream_)
-				controls_.set(controls::FrameDurations, { 100LL, 1000000000LL });
+				controls_.set(controls::FrameDurations, { INT64_C(100), INT64_C(1000000000) });
 			else if (options.framerate > 0)
 			{
 				int64_t frame_time = 1000000 / options.framerate; // in us

--- a/libcamera_still.cpp
+++ b/libcamera_still.cpp
@@ -148,7 +148,7 @@ static int get_key_or_signal(StillOptions const &options, pollfd p[1])
 		if (p[0].revents & POLLIN)
 		{
 			char *user_string = nullptr;
-			unsigned int len;
+			size_t len;
 			getline(&user_string, &len, stdin);
 			key = user_string[0];
 		}

--- a/libcamera_vid.cpp
+++ b/libcamera_vid.cpp
@@ -35,7 +35,7 @@ static int get_key_or_signal(VideoOptions const &options, pollfd p[1])
 		if (p[0].revents & POLLIN)
 		{
 			char *user_string = nullptr;
-			unsigned int len;
+			size_t len;
 			getline(&user_string, &len, stdin);
 			key = user_string[0];
 		}

--- a/mjpeg_encoder.cpp
+++ b/mjpeg_encoder.cpp
@@ -60,7 +60,7 @@ void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &it
 	cinfo.restart_interval = 0;
 
     jpeg_set_defaults(&cinfo);
-	cinfo.raw_data_in = true;
+	cinfo.raw_data_in = TRUE;
     jpeg_set_quality(&cinfo, options_.quality, TRUE);
 	encoded_buffer = nullptr;
 	buffer_len = 0;

--- a/mjpeg_encoder.cpp
+++ b/mjpeg_encoder.cpp
@@ -12,6 +12,12 @@
 
 #include "mjpeg_encoder.hpp"
 
+#if JPEG_LIB_VERSION_MAJOR > 9 || (JPEG_LIB_VERSION_MAJOR == 9 && JPEG_LIB_VERSION_MINOR >= 4)
+typedef size_t jpeg_mem_len_t;
+#else
+typedef unsigned long jpeg_mem_len_t;
+#endif
+
 MjpegEncoder::MjpegEncoder(VideoOptions const &options)
 	: Encoder(options), abort_(false), index_(0)
 {
@@ -44,7 +50,7 @@ int MjpegEncoder::EncodeBuffer(int fd, size_t size,
 }
 
 void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &item,
-							  uint8_t *&encoded_buffer, long unsigned int &buffer_len)
+							  uint8_t *&encoded_buffer, size_t &buffer_len)
 {
 	// Copied from YUV420_to_JPEG_fast in jpeg.cpp.
     cinfo.image_width = item.width;
@@ -58,7 +64,9 @@ void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &it
     jpeg_set_quality(&cinfo, options_.quality, TRUE);
 	encoded_buffer = nullptr;
 	buffer_len = 0;
-    jpeg_mem_dest(&cinfo, &encoded_buffer, &buffer_len);
+    jpeg_mem_len_t jpeg_mem_len;
+    jpeg_mem_dest(&cinfo, &encoded_buffer, &jpeg_mem_len);
+    buffer_len = jpeg_mem_len;
     jpeg_start_compress(&cinfo, TRUE);
 
 	int stride2 = item.stride / 2;
@@ -145,7 +153,7 @@ void MjpegEncoder::encodeThread(int num)
 
 		// Encode the buffer.
 		uint8_t *encoded_buffer = nullptr;
-		long unsigned int buffer_len = 0;
+		size_t buffer_len = 0;
 		auto start_time = std::chrono::high_resolution_clock::now();
 		encodeJPEG(cinfo, encode_item, encoded_buffer, buffer_len);
 		encode_time += (std::chrono::high_resolution_clock::now() - start_time);

--- a/mjpeg_encoder.hpp
+++ b/mjpeg_encoder.hpp
@@ -55,7 +55,7 @@ private:
 	std::condition_variable encode_cond_var_;
 	std::thread encode_thread_[NUM_ENC_THREADS];
 	void encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &item,
-					uint8_t *&encoded_buffer, long unsigned int &buffer_len);
+					uint8_t *&encoded_buffer, size_t &buffer_len);
 
 	struct OutputItem
 	{


### PR DESCRIPTION
Fix some findings while preparing a buildroot libcamera-apps package:

- cmake: remove unsafe host include path for libdrm (use pkgconfig instead)
- cmake: remove unrecognized gcc command-line option
- libcamera_vid: fix getline call (needs size_t)
- libcamera_still: fix getline call (needs size_t)
- libcamera_app: fix int64_t constants
- cmake: fix linking with exif, jpeg
- cmake: add install target
- cmake: no need to link against ipa_rpi.so
