### PR TITLE
Fix option parser to use "analoggain" correctly.

### DIFF
--- a/options.hpp
+++ b/options.hpp
@@ -48,7 +48,7 @@ struct Options
 			 "Set a fixed shutter speed")
 			("analoggain", value<float>(&gain)->default_value(0),
 			 "Set a fixed gain value (synonym for 'gain' option)")
-			("gain", value<float>(&gain)->default_value(0),
+			("gain", value<float>(&gain),
 			 "Set a fixed gain value")
 			("metering", value<std::string>(&metering)->default_value("centre"),
 			 "Set the metering mode (centre, spot, average, custom)")


### PR DESCRIPTION
The option parser sets a default value of 0 for "gain" and "analoggain"
if not provided.  Since they both reference the same underlying variable,
if "analoggain" is set in the command line, the variable would be rest to
the default (0) since "gain" is lower in the option list.