### PR TITLE
Buffer and metadata rework

### DIFF
--- a/libcamera_app.hpp
+++ b/libcamera_app.hpp
@@ -57,9 +57,9 @@ public:
 	using BufferMap = Request::BufferMap;
 	using Size = libcamera::Size;
 	using Rectangle = libcamera::Rectangle;
-	struct RequestCompletePayload
+	struct CompletedRequest
 	{
-		RequestCompletePayload(BufferMap const &b, ControlList const &m)
+		CompletedRequest(BufferMap const &b, ControlList const &m)
 			: buffers(b), metadata(m) {}
 		BufferMap buffers;
 		ControlList metadata;
@@ -70,7 +70,7 @@ public:
 		RequestComplete,
 		Quit
 	};
-	typedef std::variant<RequestCompletePayload, QuitPayload> MsgPayload;
+	typedef std::variant<CompletedRequest, QuitPayload> MsgPayload;
 	struct Msg
 	{
 		Msg(MsgType const &t, MsgPayload const &p) : type(t), payload(p) {}
@@ -673,7 +673,7 @@ private:
 		if (request->status() == Request::RequestCancelled)
 			return;
 
-		RequestCompletePayload payload(request->buffers(), request->metadata());
+		CompletedRequest payload(request->buffers(), request->metadata());
 		{
 			request->reuse();
 			std::lock_guard<std::mutex> lock(free_requests_mutex_);

--- a/libcamera_hello.cpp
+++ b/libcamera_hello.cpp
@@ -13,7 +13,7 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<Options> LibcameraHello;
-using RequestCompletePayload = LibcameraHello::RequestCompletePayload;
+using CompletedRequest = LibcameraHello::CompletedRequest;
 using BufferMap = LibcameraHello::BufferMap;
 
 // The main event loop for the application.
@@ -44,7 +44,7 @@ static void event_loop(LibcameraHello &app)
 			now - start_time > std::chrono::milliseconds(options.timeout))
 			return;
 
-		BufferMap &buffers = std::get<RequestCompletePayload>(msg.payload).buffers;
+		BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
 		app.ShowPreview(buffers, app.ViewfinderStream());
 	}
 }

--- a/libcamera_hello.cpp
+++ b/libcamera_hello.cpp
@@ -13,8 +13,6 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<Options> LibcameraHello;
-using CompletedRequest = LibcameraHello::CompletedRequest;
-using BufferMap = LibcameraHello::BufferMap;
 
 // The main event loop for the application.
 
@@ -44,8 +42,8 @@ static void event_loop(LibcameraHello &app)
 			now - start_time > std::chrono::milliseconds(options.timeout))
 			return;
 
-		BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
-		app.ShowPreview(buffers, app.ViewfinderStream());
+		CompletedRequest &completed_request = std::get<CompletedRequest>(msg.payload);
+		app.ShowPreview(completed_request, app.ViewfinderStream());
 	}
 }
 

--- a/libcamera_jpeg.cpp
+++ b/libcamera_jpeg.cpp
@@ -13,7 +13,7 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<StillOptions> LibcameraJpeg;
-using RequestCompletePayload = LibcameraJpeg::RequestCompletePayload;
+using CompletedRequest = LibcameraJpeg::CompletedRequest;
 using BufferMap = LibcameraJpeg::BufferMap;
 using libcamera::Stream;
 
@@ -58,7 +58,7 @@ static void event_loop(LibcameraJpeg &app)
 			}
 			else
 			{
-				BufferMap &buffers = std::get<RequestCompletePayload>(msg.payload).buffers;
+				BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
 				app.ShowPreview(buffers, app.ViewfinderStream());
 			}
 		}
@@ -71,7 +71,7 @@ static void event_loop(LibcameraJpeg &app)
 			int w, h, stride;
 			Stream *stream = app.StillStream();
 			app.StreamDimensions(stream, &w, &h, &stride);
-			RequestCompletePayload &payload = std::get<RequestCompletePayload>(msg.payload);
+			CompletedRequest &payload = std::get<CompletedRequest>(msg.payload);
 			std::vector<void *> mem = app.Mmap(payload.buffers[stream]);
 			jpeg_save(mem, w, h, stride, stream->configuration().pixelFormat,
 					  payload.metadata, app.options.output, app.CameraId(), app.options);

--- a/libcamera_jpeg.cpp
+++ b/libcamera_jpeg.cpp
@@ -13,8 +13,6 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<StillOptions> LibcameraJpeg;
-using CompletedRequest = LibcameraJpeg::CompletedRequest;
-using BufferMap = LibcameraJpeg::BufferMap;
 using libcamera::Stream;
 
 // In jpeg.cpp:
@@ -58,8 +56,8 @@ static void event_loop(LibcameraJpeg &app)
 			}
 			else
 			{
-				BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
-				app.ShowPreview(buffers, app.ViewfinderStream());
+				CompletedRequest &completed_request = std::get<CompletedRequest>(msg.payload);
+				app.ShowPreview(completed_request, app.ViewfinderStream());
 			}
 		}
 		// In still capture mode, save a jpeg and quit.

--- a/libcamera_raw.cpp
+++ b/libcamera_raw.cpp
@@ -20,8 +20,6 @@ protected:
 	void createEncoder() { encoder_ = std::unique_ptr<Encoder>(new NullEncoder(options)); }
 };
 
-using CompletedRequest = LibcameraRaw::CompletedRequest;
-
 // The main even loop for the application.
 
 static void event_loop(LibcameraRaw &app)
@@ -61,7 +59,7 @@ static void event_loop(LibcameraRaw &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload).buffers, app.RawStream());
+		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload), app.RawStream());
 	}
 }
 

--- a/libcamera_raw.cpp
+++ b/libcamera_raw.cpp
@@ -20,7 +20,7 @@ protected:
 	void createEncoder() { encoder_ = std::unique_ptr<Encoder>(new NullEncoder(options)); }
 };
 
-using RequestCompletePayload = LibcameraRaw::RequestCompletePayload;
+using CompletedRequest = LibcameraRaw::CompletedRequest;
 
 // The main even loop for the application.
 
@@ -61,7 +61,7 @@ static void event_loop(LibcameraRaw &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<RequestCompletePayload>(msg.payload).buffers, app.RawStream());
+		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload).buffers, app.RawStream());
 	}
 }
 

--- a/libcamera_still.cpp
+++ b/libcamera_still.cpp
@@ -18,7 +18,7 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<StillOptions> LibcameraStill;
-using RequestCompletePayload = LibcameraStill::RequestCompletePayload;
+using CompletedRequest = LibcameraStill::CompletedRequest;
 using BufferMap = LibcameraStill::BufferMap;
 using libcamera::Stream;
 
@@ -95,7 +95,7 @@ static void update_latest_link(std::string const &filename, StillOptions &option
 	}
 }
 
-static void save_image(LibcameraStill &app, RequestCompletePayload &payload,
+static void save_image(LibcameraStill &app, CompletedRequest &payload,
 					   Stream *stream, std::string const &filename)
 {
 	int w, h, stride;
@@ -118,7 +118,7 @@ static void save_image(LibcameraStill &app, RequestCompletePayload &payload,
 		std::cout << "Saved image " << w << " x " << h << " to file " << filename << std::endl;
 }
 
-static void save_images(LibcameraStill &app, RequestCompletePayload &payload)
+static void save_images(LibcameraStill &app, CompletedRequest &payload)
 {
 	std::string filename = generate_filename(app.options);
 	save_image(app, payload, app.StillStream(), filename);
@@ -234,7 +234,7 @@ static void event_loop(LibcameraStill &app)
 			}
 			else
 			{
-				BufferMap &buffers = std::get<RequestCompletePayload>(msg.payload).buffers;
+				BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
 				app.ShowPreview(buffers, app.ViewfinderStream());
 			}
 		}
@@ -244,7 +244,7 @@ static void event_loop(LibcameraStill &app)
 		{
 			app.StopCamera();
 			std::cout << "Still capture image received" << std::endl;
-			save_images(app, std::get<RequestCompletePayload>(msg.payload));
+			save_images(app, std::get<CompletedRequest>(msg.payload));
 			if (options.timelapse)
 			{
 				app.Teardown();

--- a/libcamera_still.cpp
+++ b/libcamera_still.cpp
@@ -18,8 +18,6 @@
 using namespace std::placeholders;
 
 typedef LibcameraApp<StillOptions> LibcameraStill;
-using CompletedRequest = LibcameraStill::CompletedRequest;
-using BufferMap = LibcameraStill::BufferMap;
 using libcamera::Stream;
 
 // In jpeg.cpp:
@@ -234,8 +232,8 @@ static void event_loop(LibcameraStill &app)
 			}
 			else
 			{
-				BufferMap &buffers = std::get<CompletedRequest>(msg.payload).buffers;
-				app.ShowPreview(buffers, app.ViewfinderStream());
+				CompletedRequest &completed_request = std::get<CompletedRequest>(msg.payload);
+				app.ShowPreview(completed_request, app.ViewfinderStream());
 			}
 		}
 		// In still capture mode, save a jpeg. Go back to viewfinder if in timelapse mode,

--- a/libcamera_vid.cpp
+++ b/libcamera_vid.cpp
@@ -16,8 +16,6 @@
 
 using namespace std::placeholders;
 
-using CompletedRequest = LibcameraEncoder::CompletedRequest;
-
 // Some keypress/signal handling.
 
 static int signal_received;
@@ -93,7 +91,7 @@ static void event_loop(LibcameraEncoder &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload).buffers, app.VideoStream());
+		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload), app.VideoStream());
 	}
 }
 

--- a/libcamera_vid.cpp
+++ b/libcamera_vid.cpp
@@ -16,7 +16,7 @@
 
 using namespace std::placeholders;
 
-using RequestCompletePayload = LibcameraEncoder::RequestCompletePayload;
+using CompletedRequest = LibcameraEncoder::CompletedRequest;
 
 // Some keypress/signal handling.
 
@@ -93,7 +93,7 @@ static void event_loop(LibcameraEncoder &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<RequestCompletePayload>(msg.payload).buffers, app.VideoStream());
+		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload).buffers, app.VideoStream());
 	}
 }
 


### PR DESCRIPTION
@naushir
Here's that re-work of the buffer and metadata passing that we were talking about. Needless to say, the original plan bit the dust almost immediately on contact with reality - I found I was making quite a lot of use of ControlLists, and didn't really want to rewrite that. The aim was never really to produce de-libcamera-ified apps, so I backed off a bit. Instead I have:

1. Renamed the RequestCompletePayload object as a BufferMetadataSet. Not sure I love this name either, but it's not as bad. Still open to other suggestions, though!

2. I've added the instantaneous framerate to the BufferMetadataSet, and it gets calculated in the requestComplete callback.

3. Now we pass BufferMetadataSets round everywhere, rather than BufferMaps. This way, the metadata ControlList and the framerate are always available.

So not as much of a change as originally intended, but nonetheless I think it should make adding things like the smart-title-bar feature more convenient. See what you think...