### PR TITLE
Fix some compiler warning.

### DIFF
--- a/circular_output.cpp
+++ b/circular_output.cpp
@@ -69,7 +69,7 @@ void CircularOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, 
 		cb_.Read([&dst](void *src, int n) { memcpy(dst, src, n); dst += n; }, sizeof(header));
 		cb_.Skip((header.length + ALIGN - 1) & ~(ALIGN - 1));
 	}
-	Header header = { static_cast<unsigned int>(size), flags & FLAG_KEYFRAME, timestamp_us };
+	Header header = { static_cast<unsigned int>(size), !!(flags & FLAG_KEYFRAME), timestamp_us };
 	cb_.Write(&header, sizeof(header));
 	cb_.Write(mem, size);
 	cb_.Pad(pad);

--- a/h264_encoder.cpp
+++ b/h264_encoder.cpp
@@ -278,7 +278,7 @@ void H264Encoder::pollThread()
 									buf.m.planes[0].bytesused,
 									buf.m.planes[0].length,
 									buf.index,
-									buf.flags & V4L2_BUF_FLAG_KEYFRAME,
+									!!(buf.flags & V4L2_BUF_FLAG_KEYFRAME),
 									timestamp_us };
 				std::lock_guard<std::mutex> lock(output_mutex_);
 				output_queue_.push(item);

--- a/libcamera_still.cpp
+++ b/libcamera_still.cpp
@@ -147,7 +147,7 @@ static int get_key_or_signal(StillOptions const &options, pollfd p[1])
 		{
 			char *user_string = nullptr;
 			size_t len;
-			getline(&user_string, &len, stdin);
+			[[maybe_unused]] size_t r = getline(&user_string, &len, stdin);
 			key = user_string[0];
 		}
 	}

--- a/libcamera_vid.cpp
+++ b/libcamera_vid.cpp
@@ -34,7 +34,7 @@ static int get_key_or_signal(VideoOptions const &options, pollfd p[1])
 		{
 			char *user_string = nullptr;
 			size_t len;
-			getline(&user_string, &len, stdin);
+			[[maybe_unused]] size_t r = getline(&user_string, &len, stdin);
 			key = user_string[0];
 		}
 	}

--- a/output.cpp
+++ b/output.cpp
@@ -5,6 +5,7 @@
  * output.cpp - video stream output base class
  */
 
+#include <cinttypes>
 #include <stdexcept>
 
 #include "output.hpp"
@@ -60,7 +61,7 @@ void Output::OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyf
 
 	// Save timestamps to a file, if that was requested.
 	if (fp_timestamps_)
-		fprintf(fp_timestamps_, "%lld.%03lld\n", last_timestamp_ / 1000, last_timestamp_ % 1000);
+		fprintf(fp_timestamps_, PRId64 ".%03" PRId64 "\n", last_timestamp_ / 1000, last_timestamp_ % 1000);
 }
 
 void Output::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t flags)


### PR DESCRIPTION
- Unused return value from getline().
- printf format specifiers for 64-bit integers.
- Warning about narrowing conversion from int to bool.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>