### PR TITLE
Make DRM preview fail earlier if we are not DRM master

### DIFF
--- a/drm_preview.cpp
+++ b/drm_preview.cpp
@@ -170,6 +170,9 @@ DrmPreview::DrmPreview(Options const &options) : last_fd_(-1), Preview(options)
 
 	try
 	{
+		if (!drmIsMaster(drmfd_))
+			throw std::runtime_error("DRM preview unavailable - not master");
+
 		conId_ = 0;
 		findCrtc();
 		out_fourcc_ = DRM_FORMAT_YUV420;


### PR DESCRIPTION
It will fail later anyway, so it's more helpful to raise a specific
error immediately.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>