### PR TITLE
libcamera-raw: Force colour denoise off

### DIFF
--- a/libcamera_raw.cpp
+++ b/libcamera_raw.cpp
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
 		LibcameraRaw app;
 		if (app.options.Parse(argc, argv))
 		{
+			app.options.denoise = "cdn_off";
 			app.options.nopreview = true;
 			if (app.options.verbose)
 				app.options.Print();


### PR DESCRIPTION
It serves no purpose here, and might slow up the framerate.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>