### PR TITLE
libcamera-raw: Fix video capture with full res raw images

### DIFF
--- a/libcamera_app.hpp
+++ b/libcamera_app.hpp
@@ -276,10 +276,13 @@ public:
 			configuration_->at(0).size.width = options.width;
 		if (options.height)
 			configuration_->at(0).size.height = options.height;
-		if ((flags & FLAG_VIDEO_RAW) && !options.rawfull)
+		if (flags & FLAG_VIDEO_RAW)
 		{
-			configuration_->at(1).size.width = configuration_->at(0).size.width;
-			configuration_->at(1).size.height = configuration_->at(0).size.height;
+			if (!options.rawfull)
+			{
+				configuration_->at(1).size.width = configuration_->at(0).size.width;
+				configuration_->at(1).size.height = configuration_->at(0).size.height;
+			}
 			configuration_->at(1).bufferCount = configuration_->at(0).bufferCount;
 		}
 		configuration_->transform = options.transform;


### PR DESCRIPTION
The number of raw buffers must be set up to match the number of output
buffers, unconditionally. libcamera_app.hpp requires all streams that
will feature in the same requests to have the same number of buffers
available.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>