### PR TITLE
mjpeg_encoder: fix bug that truncated jpegs to 4096 bytes

### DIFF
--- a/mjpeg_encoder.cpp
+++ b/mjpeg_encoder.cpp
@@ -66,7 +66,6 @@ void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &it
 	buffer_len = 0;
     jpeg_mem_len_t jpeg_mem_len;
     jpeg_mem_dest(&cinfo, &encoded_buffer, &jpeg_mem_len);
-    buffer_len = jpeg_mem_len;
     jpeg_start_compress(&cinfo, TRUE);
 
 	int stride2 = item.stride / 2;
@@ -113,6 +112,7 @@ void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &it
 	}
 
     jpeg_finish_compress(&cinfo);
+    buffer_len = jpeg_mem_len;
 }
 
 void MjpegEncoder::encodeThread(int num)

--- a/test.py
+++ b/test.py
@@ -257,7 +257,8 @@ def test_vid(dir):
                                          logfile)
     check_retcode(retcode, "test_vid: segment test")
     check_time(time_taken, 2, 5, "test_vid: segment test")
-    check_size(os.path.join(dir, 'test035.jpg'), 1024, "test_vid: segment test")
+    # A bug in commit b20dc097621a trunctated each jpg to 4096 bytes, so check against 4100:
+    check_size(os.path.join(dir, 'test035.jpg'), 4100, "test_vid: segment test")
 
     # "circular test". Test circular buffer (really we should wait for it to wrap...)
     print("    circular test")


### PR DESCRIPTION
Fixing up some type warnings had caused the jpeg length not to be
returned correctly from the encodeJPEG method.

Test script has also been altered to spot this.

Fixes: b20dc097621a ("fix buildroot crosscompile (#1)")
Signed-off-by: David Plowman <david.plowman@raspberrypi.com>