### PR TITLE
Make interface from libcameraApp to Encoder cleaner

### DIFF
--- a/encoder.hpp
+++ b/encoder.hpp
@@ -11,7 +11,7 @@
 
 #include "video_options.hpp"
 
-typedef std::function<void(int)> InputDoneCallback;
+typedef std::function<void(void *)> InputDoneCallback;
 typedef std::function<void(void *,size_t, int64_t, bool)> OutputReadyCallback;
 
 class Encoder
@@ -36,9 +36,9 @@ public:
 	}
 	// Encode the given buffer. The buffer is specified both by an fd and size
 	// describing a DMABUF, and by a mmapped userland pointer.
-	virtual int EncodeBuffer(int fd, size_t size,
-							 void *mem, int width, int height, int stride,
-							 int64_t timestamp_us) = 0;
+	virtual void EncodeBuffer(int fd, size_t size,
+							  void *mem, int width, int height, int stride,
+							  int64_t timestamp_us) = 0;
 protected:
 	InputDoneCallback input_done_callback_;
 	OutputReadyCallback output_ready_callback_;

--- a/h264_encoder.hpp
+++ b/h264_encoder.hpp
@@ -20,9 +20,9 @@ public:
 	H264Encoder(VideoOptions const &options);
 	~H264Encoder();
 	// Encode the given DMABUF.
-	int EncodeBuffer(int fd, size_t size,
-					 void *mem, int width, int height, int stride,
-					 int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size,
+					  void *mem, int width, int height, int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	// We want at least as many output buffers as there are in the camera queue

--- a/libcamera_encoder.hpp
+++ b/libcamera_encoder.hpp
@@ -48,9 +48,8 @@ public:
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);
 			encode_buffer_queue_.push(std::move(completed_request));
 		}
-		int index = encoder_->EncodeBuffer(buffer->planes()[0].fd.fd(), buffer->planes()[0].length,
-										   mem, w, h, stride, timestamp_ns / 1000);
-		// Could use index as a reference to this buffer, but we don't seem to need it.
+		encoder_->EncodeBuffer(buffer->planes()[0].fd.fd(), buffer->planes()[0].length,
+							   mem, w, h, stride, timestamp_ns / 1000);
 	}
 	void StopEncoder()
 	{
@@ -65,9 +64,13 @@ protected:
 	std::unique_ptr<Encoder> encoder_;
 
 private:
-	void encodeBufferDone(int index)
+	void encodeBufferDone(void *mem)
 	{
-		(void)index; // don't appear to need it if we assume the codec returns them in order
+		// If non-NULL, mem would indicate which buffer has been completed, but
+		// currently we're just assuming everything is done in order. (We could
+		// handle this by replacing the queue with a vector of <mem, completed_request>
+		// pairs.)
+		assert(mem == nullptr);
 		CompletedRequest completed_request;
 		{
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);

--- a/mjpeg_encoder.hpp
+++ b/mjpeg_encoder.hpp
@@ -22,9 +22,9 @@ public:
 	MjpegEncoder(VideoOptions const &options);
 	~MjpegEncoder();
 	// Encode the given buffer.
-	int EncodeBuffer(int fd, size_t size,
-					 void *mem, int width, int height, int stride,
-					 int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size,
+					  void *mem, int width, int height, int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	// How many threads to use. We toss frames at each thread in turn.
@@ -47,7 +47,6 @@ private:
 		int width;
 		int height;
 		int stride;
-		int index;
 		int64_t timestamp_us;
 	};
 	std::queue<EncodeItem> encode_queue_[NUM_ENC_THREADS];
@@ -61,7 +60,6 @@ private:
 	{
 		void *mem;
 		size_t bytes_used;
-		int index;
 		int64_t timestamp_us;
 	};
 	std::queue<OutputItem> output_queue_[NUM_ENC_THREADS];

--- a/null_encoder.hpp
+++ b/null_encoder.hpp
@@ -20,9 +20,9 @@ class NullEncoder : public Encoder
 public:
 	NullEncoder(VideoOptions const &options);
 	~NullEncoder();
-	int EncodeBuffer(int fd, size_t size,
-					 void *mem, int width, int height, int stride,
-					 int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size,
+					  void *mem, int width, int height, int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	void outputThread();
@@ -39,6 +39,4 @@ private:
 	std::mutex output_mutex_;
 	std::condition_variable output_cond_var_;
 	std::thread output_thread_;
-	unsigned int input_count_;
-	unsigned int output_count_;
 };


### PR DESCRIPTION
Previously LibcameraEncoder::EncodeBuffer used to return a handle
that would in theory allow an encoder to return buffers out-of-order
(though LibcameraEncoder::encodeBufferDone never handled this). This
entangles the LibcameraEncoder and the Encoder together more than is
necessary.

Instead, use the memory pointer, which we already have, as the
handle. This will make it easier to handle out-of-order completion,
should we choose to do so in future.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>