### PR TITLE
Improve viewfinder resolution selection

### DIFF
--- a/options.hpp
+++ b/options.hpp
@@ -81,6 +81,10 @@ struct Options
 			 "Set the fixed framerate for preview and video modes")
 			("denoise", value<std::string>(&denoise)->default_value("auto"),
 			 "Sets the Denoise operating mode: auto, off, cdn_off, cdn_fast, cdn_hq")
+			("viewfinder-width", value<unsigned int>(&viewfinder_width)->default_value(0),
+			 "Width of viewfinder frames from the camera (distinct from the preview window size")
+			("viewfinder-height", value<unsigned int>(&viewfinder_height)->default_value(0),
+			 "Height of viewfinder frames from the camera (distinct from the preview window size)")
 			;
 	}
 
@@ -119,6 +123,8 @@ struct Options
 	float framerate;
 	std::string denoise;
 	std::string info_text;
+	unsigned int viewfinder_width;
+	unsigned int viewfinder_height;
 
 	virtual bool Parse(int argc, char *argv[])
 	{
@@ -241,6 +247,8 @@ struct Options
 		std::cout << "    sharpness: " << sharpness << std::endl;
 		std::cout << "    framerate: " << framerate << std::endl;
 		std::cout << "    denoise: " << denoise << std::endl;
+		std::cout << "    viewfinder-width: " << viewfinder_width << std::endl;
+		std::cout << "    viewfinder-height: " << viewfinder_height << std::endl;
 	}
 
 protected:


### PR DESCRIPTION
Previously, the fixed resolution could cause the selection of an
unexpected camera mode. Now we default to half the full sensor
resolution, which should pick out 2x2 binned modes fairly reliably (if
available).  Additionally, we trim the size to the same aspect ratio
as the full resolution capture, if one is expected, so as to match the
field of view.

Furthermore, we add viewfinder-width and viewfinder-height options, so
the resolution can be forced, should the above produce undesirable
results. We note that the word "preview" has already been used in
conjunction with the preview window size, and is therefore distinct.

Finally, configureDenoise is rejigged slightly so that "auto"
corresponds to "cdn_off" in viewfinder mode, as the full HQ cam 2x2
binned mode will cause frame drops. It can be forced back on with the
denoise option, if necessary, and the meaning of "auto" for video or
still modes is unchanged.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>