### PR TITLE
Mjpeg improvements

### DIFF
--- a/libcamera_app.hpp
+++ b/libcamera_app.hpp
@@ -289,6 +289,7 @@ public:
 
 		// Now we get to override any of the default settings from the options.
 		configuration_->at(0).pixelFormat = libcamera::formats::YUV420;
+		configuration_->at(0).bufferCount = 6; // 6 buffers is better than 4
 		if (options.width)
 			configuration_->at(0).size.width = options.width;
 		if (options.height)

--- a/mjpeg_encoder.hpp
+++ b/mjpeg_encoder.hpp
@@ -27,7 +27,7 @@ public:
 					  int64_t timestamp_us) override;
 
 private:
-	// How many threads to use. We toss frames at each thread in turn.
+	// How many threads to use. Whichever thread is idle will pick up the next frame.
 	static const int NUM_ENC_THREADS = 4;
 
 	// These threads do the actual encoding.
@@ -39,7 +39,7 @@ private:
 	void outputThread();
 
 	bool abort_;
-	int index_;
+	uint64_t index_;
 
 	struct EncodeItem
 	{
@@ -48,8 +48,9 @@ private:
 		int height;
 		int stride;
 		int64_t timestamp_us;
+		uint64_t index;
 	};
-	std::queue<EncodeItem> encode_queue_[NUM_ENC_THREADS];
+	std::queue<EncodeItem> encode_queue_;
 	std::mutex encode_mutex_;
 	std::condition_variable encode_cond_var_;
 	std::thread encode_thread_[NUM_ENC_THREADS];
@@ -61,6 +62,7 @@ private:
 		void *mem;
 		size_t bytes_used;
 		int64_t timestamp_us;
+		uint64_t index;
 	};
 	std::queue<OutputItem> output_queue_[NUM_ENC_THREADS];
 	std::mutex output_mutex_;


### PR DESCRIPTION
@naushir Some modest improvements to mjpeg throughput.

I've changed the way the multiple threads in the mjpeg encoder work slightly. I think this arrangement is marginally better and is probably a better template to copy in future work.

And I've upped the buffer count for video to 6. It does result in fewer frame drops when working mjpeg quite hard. Note the mjpeg throughput is somewhat sensitive to both the preview window and colour denoise!