### PR TITLE
encoder: Do not explicitly set buffer size and bytesperline in format struct

### DIFF
--- a/h264_encoder.cpp
+++ b/h264_encoder.cpp
@@ -102,9 +102,6 @@ H264Encoder::H264Encoder(VideoOptions const &options) : Encoder(options), abort_
 	// libcamera currently has no means to request the right colour space, hence:
 	fmt.fmt.pix_mp.colorspace = V4L2_COLORSPACE_JPEG;
 	fmt.fmt.pix_mp.num_planes = 1;
-	fmt.fmt.pix_mp.plane_fmt[0].bytesperline = ((options.width + 31) & ~31);
-	fmt.fmt.pix_mp.plane_fmt[0].sizeimage =
-		fmt.fmt.pix_mp.plane_fmt[0].bytesperline * fmt.fmt.pix_mp.height * 3 / 2;
 	if (xioctl(fd_, VIDIOC_S_FMT, &fmt) < 0)
 		throw std::runtime_error("failed to set output format");
 


### PR DESCRIPTION
Given that we are using dmabufs, these fields do not seem to be necessary to
fill in the format structure.