### PR TITLE
checkstyle: Update license to "GPL-2.0-or-later" for the script

### DIFF
--- a/checkstyle.py
+++ b/checkstyle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # checkstyle.py - A patch style checker script based on clang-format
 #


### PR DESCRIPTION
Use the original authorship licence of the checkstyle.py script file. It was
erroneously set to the default of "BSD-2-Clause" for this repository.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>