### PR TITLE
Remove c++17 reference from .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -103,7 +103,6 @@ SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++17
 IndentWidth: 4
 TabWidth: 4
 UseTab: Always


### PR DESCRIPTION
The Pi repos are not yet shipping with a version of clang-format that
supports c++17, so this parameter causes commits to fail if you are
doing them directly from the Pi.

For the time being little is lost by omitting it, and we can replace
it once the repositories have moved on.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>