### PR TITLE
cmake: Use pkg_check_modules for libcamera, x11, epoxy, and libdrm li…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required(VERSION 3.6)
 project(libcamera-apps)
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
-  if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
-    message(STATUS "No previous build - default to Release build")
-  endif()
+    if (NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
+        message(STATUS "No previous build - default to Release build")
+    endif()
 endif()
 
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -17,27 +17,27 @@ add_definitions(-Wno-psabi)
 add_definitions(-DBOOST_LOG_DYN_LINK)
 
 IF (NOT ENABLE_COMPILE_FLAGS_FOR_TARGET)
-  # On a Pi this will give us armhf or arm64.
-  execute_process(COMMAND dpkg-architecture -qDEB_HOST_ARCH
-    OUTPUT_VARIABLE ENABLE_COMPILE_FLAGS_FOR_TARGET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # On a Pi this will give us armhf or arm64.
+    execute_process(COMMAND dpkg-architecture -qDEB_HOST_ARCH
+        OUTPUT_VARIABLE ENABLE_COMPILE_FLAGS_FOR_TARGET OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 message(STATUS "Platform: ${ENABLE_COMPILE_FLAGS_FOR_TARGET}")
 if ("${ENABLE_COMPILE_FLAGS_FOR_TARGET}" STREQUAL "arm64")
-  # 64-bit binaries can be fully optimised.
-  add_definitions(-ftree-vectorize)
+    # 64-bit binaries can be fully optimised.
+    add_definitions(-ftree-vectorize)
 elseif ("${ENABLE_COMPILE_FLAGS_FOR_TARGET}" STREQUAL "armv8-neon")
-  # Only build with 32-bit Pi 3/4 specific optimisations if requested on the command line.
-  add_definitions(-mfpu=neon-fp-armv8 -ftree-vectorize)
+    # Only build with 32-bit Pi 3/4 specific optimisations if requested on the command line.
+    add_definitions(-mfpu=neon-fp-armv8 -ftree-vectorize)
 endif()
 
 find_package(PkgConfig REQUIRED)
 
-pkg_check_modules(CAMERA REQUIRED libcamera)
-find_library(LIBCAMERA_LIBRARY libcamera.so REQUIRED)
-find_library(LIBCAMERA_BASE_LIBRARY libcamera-base.so REQUIRED)
-set(LIBCAMERA_LIBRARIES ${LIBCAMERA_LIBRARY} ${LIBCAMERA_BASE_LIBRARY})
-message(STATUS ${LIBCAMERA_LIBRARIES})
-include_directories(${CMAKE_SOURCE_DIR} ${CAMERA_INCLUDE_DIRS})
+pkg_check_modules(LIBCAMERA REQUIRED libcamera)
+message(STATUS "libcamera library found:")
+message(STATUS "    version: ${LIBCAMERA_VERSION}")
+message(STATUS "    libraries: ${LIBCAMERA_LINK_LIBRARIES}")
+message(STATUS "    include path: ${LIBCAMERA_INCLUDE_DIRS}")
+include_directories(${CMAKE_SOURCE_DIR} ${LIBCAMERA_INCLUDE_DIRS})
 
 add_subdirectory(apps)
 add_subdirectory(core)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set (CMAKE_CXX_STANDARD 17)
 set (CMAKE CXX_FLAGS "-Wall -Wextra -pedantic -Wno-unused-parameter -faligned-new")
 add_definitions(-Wfatal-errors)
 add_definitions(-Wno-psabi)
-add_definitions(-DBOOST_LOG_DYN_LINK)
 
 IF (NOT ENABLE_COMPILE_FLAGS_FOR_TARGET)
     # On a Pi this will give us armhf or arm64.

--- a/preview/CMakeLists.txt
+++ b/preview/CMakeLists.txt
@@ -1,18 +1,17 @@
 cmake_minimum_required(VERSION 3.6)
 
 pkg_check_modules(LIBDRM REQUIRED libdrm)
+pkg_check_modules(X11 REQUIRED x11)
+pkg_check_modules(EPOXY REQUIRED epoxy)
 
-find_package(X11 REQUIRED)
-message(STATUS "${X11_INCLUDE_DIR}")
-find_library(EPOXY_LIBRARY libepoxy.so REQUIRED)
-message(STATUS "${EPOXY_LIBRARY}")
-find_library(DRM_LIBRARY libdrm.so REQUIRED)
-message(STATUS "${DRM_LIBRARY}")
+message(STATUS "LIBDRM_LINK_LIBRARIES=${LIBDRM_LINK_LIBRARIES}")
+message(STATUS "X11_LINK_LIBRARIES=${X11_LINK_LIBRARIES}")
+message(STATUS "EPOXY_LINK_LIBRARIES=${EPOXY_LINK_LIBRARIES}")
 
 include_directories(${LIBDRM_INCLUDE_DIRS})
 
 add_library(preview egl_preview.cpp drm_preview.cpp null_preview.cpp)
-target_link_libraries(preview ${DRM_LIBRARY} ${X11_LIBRARIES} ${EPOXY_LIBRARY})
+target_link_libraries(preview ${LIBDRM_LIBRARIES} ${X11_LIBRARIES} ${EPOXY_LIBRARIES})
 
 install(TARGETS preview LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 


### PR DESCRIPTION
…braries

There was a mix of pkg_check_modules and find_library usage that is now cleaned
up.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>