### PR TITLE
build: Fix error linking to libcamera-base.so

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 
 add_library(libcamera_app libcamera_app.cpp)
 set_target_properties(libcamera_app PROPERTIES PREFIX "" IMPORT_PREFIX "")
-target_link_libraries(libcamera_app pthread images preview ${LIBCAMERA_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(libcamera_app pthread images preview ${LIBCAMERA_LINK_LIBRARIES} ${Boost_LIBRARIES})
 
 install(TARGETS libcamera_app LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 


### PR DESCRIPTION
It's a bit strange why this did not fail all the time.
I suspect the "wrong" variable may have been cached by cmake, so it kept working when it should not have been!