### PR TITLE
Add support for a low resolution stream

### DIFF
--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -116,6 +116,7 @@ public:
 	void QueueRequest(CompletedRequest const &completed_request);
 	void PostMessage(MsgType &t, MsgPayload &p);
 
+	Stream *GetStream(std::string const &name, int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *ViewfinderStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *StillStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *RawStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
@@ -190,10 +191,7 @@ private:
 	bool camera_acquired_ = false;
 	std::unique_ptr<CameraConfiguration> configuration_;
 	std::map<FrameBuffer *, std::vector<void *>> mapped_buffers_;
-	Stream *viewfinder_stream_ = nullptr;
-	Stream *still_stream_ = nullptr;
-	Stream *raw_stream_ = nullptr;
-	Stream *video_stream_ = nullptr;
+	std::map<std::string, Stream *> streams_;
 	FrameBufferAllocator *allocator_ = nullptr;
 	std::map<Stream *, std::queue<FrameBuffer *>> frame_buffers_;
 	std::mutex free_requests_mutex_;

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -121,6 +121,7 @@ public:
 	Stream *StillStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *RawStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *VideoStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
+	Stream *LoresStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 
 	std::vector<void *> Mmap(FrameBuffer *buffer) const;
 

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -92,6 +92,10 @@ struct Options
 			 "Height of viewfinder frames from the camera (distinct from the preview window size)")
 			("tuning-file", value<std::string>(&tuning_file)->default_value("-"),
 			 "Name of camera tuning file to use, omit this option for libcamera default behaviour")
+			("lores-width", value<unsigned int>(&lores_width)->default_value(0),
+			 "Width of low resolution frames (use 0 to omit low resolution stream")
+			("lores-height", value<unsigned int>(&lores_height)->default_value(0),
+			 "Height of low resolution frames (use 0 to omit low resolution stream")
 			;
 	}
 
@@ -134,6 +138,8 @@ struct Options
 	unsigned int viewfinder_width;
 	unsigned int viewfinder_height;
 	std::string tuning_file;
+	unsigned int lores_width;
+	unsigned int lores_height;
 
 	virtual bool Parse(int argc, char *argv[])
 	{
@@ -272,6 +278,8 @@ struct Options
 		std::cout << "    viewfinder-width: " << viewfinder_width << std::endl;
 		std::cout << "    viewfinder-height: " << viewfinder_height << std::endl;
 		std::cout << "    tuning-file: " << (tuning_file == "-" ? "(libcamera)" : tuning_file) << std::endl;
+		std::cout << "    lores-width: " << lores_width << std::endl;
+		std::cout << "    lores-height: " << lores_height << std::endl;
 	}
 
 protected:


### PR DESCRIPTION
Viewfinder and video modes can supply an extra "lores" stream,
specified by the --lores-width and --lores-height command line
parameters.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>