### PR TITLE
Lores stream

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -127,7 +127,11 @@ void LibcameraApp::ConfigureViewfinder()
 	if (options_->verbose)
 		std::cout << "Configuring viewfinder..." << std::endl;
 
-	configuration_ = camera_->generateConfiguration({ StreamRole::Viewfinder });
+	bool have_lores_stream = options_->lores_width && options_->lores_height;
+	StreamRoles stream_roles = { StreamRole::Viewfinder };
+	if (have_lores_stream)
+		stream_roles.push_back(StreamRole::Viewfinder);
+	configuration_ = camera_->generateConfiguration(stream_roles);
 	if (!configuration_)
 		throw std::runtime_error("failed to generate viewfinder configuration");
 
@@ -152,6 +156,18 @@ void LibcameraApp::ConfigureViewfinder()
 	// Now we get to override any of the default settings from the options_->
 	configuration_->at(0).pixelFormat = libcamera::formats::YUV420;
 	configuration_->at(0).size = size;
+
+	if (have_lores_stream)
+	{
+		Size lores_size(options_->lores_width, options_->lores_height);
+		lores_size.alignDownTo(2, 2);
+		if (lores_size.width > size.width || lores_size.height > size.height)
+			throw std::runtime_error("Low res image larger than viewfinder");
+		configuration_->at(1).pixelFormat = libcamera::formats::YUV420;
+		configuration_->at(1).size = lores_size;
+		configuration_->at(1).bufferCount = configuration_->at(0).bufferCount;
+	}
+
 	configuration_->transform = options_->transform;
 
 	post_processor_.AdjustConfig("viewfinder", &configuration_->at(0));
@@ -160,6 +176,8 @@ void LibcameraApp::ConfigureViewfinder()
 	setupCapture();
 
 	streams_["viewfinder"] = configuration_->at(0).stream();
+	if (have_lores_stream)
+		streams_["lores"] = configuration_->at(1).stream();
 
 	post_processor_.Configure();
 
@@ -225,11 +243,17 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 	if (options_->verbose)
 		std::cout << "Configuring video..." << std::endl;
 
-	StreamRoles stream_roles;
-	if (flags & FLAG_VIDEO_RAW)
-		stream_roles = { StreamRole::VideoRecording, StreamRole::Raw };
-	else
-		stream_roles = { StreamRole::VideoRecording };
+	bool have_raw_stream = flags & FLAG_VIDEO_RAW;
+	bool have_lores_stream = options_->lores_width && options_->lores_height;
+	StreamRoles stream_roles = { StreamRole::VideoRecording };
+	int lores_index = 1;
+	if (have_raw_stream)
+	{
+		stream_roles.push_back(StreamRole::Raw);
+		lores_index = 2;
+	}
+	if (have_lores_stream)
+		stream_roles.push_back(StreamRole::Viewfinder);
 	configuration_ = camera_->generateConfiguration(stream_roles);
 	if (!configuration_)
 		throw std::runtime_error("failed to generate video configuration");
@@ -245,7 +269,7 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 
 	post_processor_.AdjustConfig("video", &configuration_->at(0));
 
-	if (flags & FLAG_VIDEO_RAW)
+	if (have_raw_stream)
 	{
 		if (!options_->rawfull)
 		{
@@ -254,12 +278,27 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 		}
 		configuration_->at(1).bufferCount = configuration_->at(0).bufferCount;
 	}
+	if (have_lores_stream)
+	{
+		Size lores_size(options_->lores_width, options_->lores_height);
+		lores_size.alignDownTo(2, 2);
+		if (lores_size.width > configuration_->at(0).size.width ||
+			lores_size.height > configuration_->at(0).size.height)
+			throw std::runtime_error("Low res image larger than video");
+		configuration_->at(lores_index).pixelFormat = libcamera::formats::YUV420;
+		configuration_->at(lores_index).size = lores_size;
+		configuration_->at(lores_index).bufferCount = configuration_->at(0).bufferCount;
+	}
+	configuration_->transform = options_->transform;
 
 	configureDenoise(options_->denoise == "auto" ? "cdn_fast" : options_->denoise);
 	setupCapture();
 
 	streams_["video"] = configuration_->at(0).stream();
-	streams_["raw"] = configuration_->at(1).stream();
+	if (have_raw_stream)
+		streams_["raw"] = configuration_->at(1).stream();
+	if (have_lores_stream)
+		streams_["lores"] = configuration_->at(lores_index).stream();
 
 	post_processor_.Configure();
 
@@ -488,6 +527,11 @@ libcamera::Stream *LibcameraApp::RawStream(int *w, int *h, int *stride) const
 libcamera::Stream *LibcameraApp::VideoStream(int *w, int *h, int *stride) const
 {
 	return GetStream("video", w, h, stride);
+}
+
+libcamera::Stream *LibcameraApp::LoresStream(int *w, int *h, int *stride) const
+{
+	return GetStream("lores", w, h, stride);
 }
 
 libcamera::Stream *LibcameraApp::GetMainStream() const

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -159,7 +159,7 @@ void LibcameraApp::ConfigureViewfinder()
 	configureDenoise(options_->denoise == "auto" ? "cdn_off" : options_->denoise);
 	setupCapture();
 
-	viewfinder_stream_ = configuration_->at(0).stream();
+	streams_["viewfinder"] = configuration_->at(0).stream();
 
 	post_processor_.Configure();
 
@@ -211,8 +211,8 @@ void LibcameraApp::ConfigureStill(unsigned int flags)
 	configureDenoise(options_->denoise == "auto" ? "cdn_hq" : options_->denoise);
 	setupCapture();
 
-	still_stream_ = configuration_->at(0).stream();
-	raw_stream_ = configuration_->at(1).stream();
+	streams_["still"] = configuration_->at(0).stream();
+	streams_["raw"] = configuration_->at(1).stream();
 
 	post_processor_.Configure();
 
@@ -258,8 +258,8 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 	configureDenoise(options_->denoise == "auto" ? "cdn_fast" : options_->denoise);
 	setupCapture();
 
-	video_stream_ = configuration_->at(0).stream();
-	raw_stream_ = configuration_->at(1).stream();
+	streams_["video"] = configuration_->at(0).stream();
+	streams_["raw"] = configuration_->at(1).stream();
 
 	post_processor_.Configure();
 
@@ -290,10 +290,7 @@ void LibcameraApp::Teardown()
 
 	frame_buffers_.clear();
 
-	viewfinder_stream_ = nullptr;
-	still_stream_ = nullptr;
-	raw_stream_ = nullptr;
-	video_stream_ = nullptr;
+	streams_.clear();
 }
 
 void LibcameraApp::StartCamera()
@@ -322,7 +319,7 @@ void LibcameraApp::StartCamera()
 	// as long as possible so that we get whatever the exposure profile wants.
 	if (!controls_.contains(controls::FrameDurationLimits))
 	{
-		if (still_stream_)
+		if (StillStream())
 			controls_.set(controls::FrameDurationLimits, { INT64_C(100), INT64_C(1000000000) });
 		else if (options_->framerate > 0)
 		{
@@ -464,53 +461,41 @@ void LibcameraApp::PostMessage(MsgType &t, MsgPayload &p)
 	msg_queue_.Post(Msg(t, p));
 }
 
+libcamera::Stream *LibcameraApp::GetStream(std::string const &name, int *w, int *h, int *stride) const
+{
+	auto it = streams_.find(name);
+	if (it == streams_.end())
+		return nullptr;
+	StreamDimensions(it->second, w, h, stride);
+	return it->second;
+}
+
 libcamera::Stream *LibcameraApp::ViewfinderStream(int *w, int *h, int *stride) const
 {
-	if (viewfinder_stream_)
-		StreamDimensions(viewfinder_stream_, w, h, stride);
-	return viewfinder_stream_;
+	return GetStream("viewfinder", w, h, stride);
 }
 
 libcamera::Stream *LibcameraApp::StillStream(int *w, int *h, int *stride) const
 {
-	if (still_stream_)
-		StreamDimensions(still_stream_, w, h, stride);
-	return still_stream_;
+	return GetStream("still", w, h, stride);
 }
 
 libcamera::Stream *LibcameraApp::RawStream(int *w, int *h, int *stride) const
 {
-	if (raw_stream_)
-		StreamDimensions(raw_stream_, w, h, stride);
-	return raw_stream_;
+	return GetStream("raw", w, h, stride);
 }
 
 libcamera::Stream *LibcameraApp::VideoStream(int *w, int *h, int *stride) const
 {
-	if (video_stream_)
-		StreamDimensions(video_stream_, w, h, stride);
-	return video_stream_;
+	return GetStream("video", w, h, stride);
 }
 
 libcamera::Stream *LibcameraApp::GetMainStream() const
 {
-	std::vector<libcamera::Stream *> streams;
-
-	if (viewfinder_stream_ != nullptr)
+	for (auto &p : streams_)
 	{
-		return viewfinder_stream_;
-	}
-	if (still_stream_ != nullptr)
-	{
-		return still_stream_;
-	}
-	if (raw_stream_ != nullptr)
-	{
-		return raw_stream_;
-	}
-	if (video_stream_ != nullptr)
-	{
-		return video_stream_;
+		if (p.first == "viewfinder" || p.first == "still" || p.first == "video")
+			return p.second;
 	}
 
 	return nullptr;

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -110,6 +110,7 @@ public:
 	Stream *StillStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *RawStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *VideoStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
+	Stream *LoresStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *GetMainStream() const;
 
 	std::vector<libcamera::Span<uint8_t>> Mmap(FrameBuffer *buffer) const;

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -105,6 +105,7 @@ public:
 	void QueueRequest(CompletedRequest const &completed_request);
 	void PostMessage(MsgType &t, MsgPayload &p);
 
+	Stream *GetStream(std::string const &name, int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *ViewfinderStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *StillStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
 	Stream *RawStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
@@ -180,10 +181,7 @@ private:
 	bool camera_acquired_ = false;
 	std::unique_ptr<CameraConfiguration> configuration_;
 	std::map<FrameBuffer *, std::vector<libcamera::Span<uint8_t>>> mapped_buffers_;
-	Stream *viewfinder_stream_ = nullptr;
-	Stream *still_stream_ = nullptr;
-	Stream *raw_stream_ = nullptr;
-	Stream *video_stream_ = nullptr;
+	std::map<std::string, Stream *> streams_;
 	FrameBufferAllocator *allocator_ = nullptr;
 	std::map<Stream *, std::queue<FrameBuffer *>> frame_buffers_;
 	std::mutex free_requests_mutex_;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -94,6 +94,10 @@ struct Options
 			 "Height of viewfinder frames from the camera (distinct from the preview window size)")
 			("tuning-file", value<std::string>(&tuning_file)->default_value("-"),
 			 "Name of camera tuning file to use, omit this option for libcamera default behaviour")
+			("lores-width", value<unsigned int>(&lores_width)->default_value(0),
+			 "Width of low resolution frames (use 0 to omit low resolution stream")
+			("lores-height", value<unsigned int>(&lores_height)->default_value(0),
+			 "Height of low resolution frames (use 0 to omit low resolution stream")
 			;
 	}
 
@@ -137,6 +141,8 @@ struct Options
 	unsigned int viewfinder_width;
 	unsigned int viewfinder_height;
 	std::string tuning_file;
+	unsigned int lores_width;
+	unsigned int lores_height;
 
 	virtual bool Parse(int argc, char *argv[])
 	{
@@ -276,6 +282,8 @@ struct Options
 		std::cout << "    viewfinder-width: " << viewfinder_width << std::endl;
 		std::cout << "    viewfinder-height: " << viewfinder_height << std::endl;
 		std::cout << "    tuning-file: " << (tuning_file == "-" ? "(libcamera)" : tuning_file) << std::endl;
+		std::cout << "    lores-width: " << lores_width << std::endl;
+		std::cout << "    lores-height: " << lores_height << std::endl;
 	}
 
 protected:


### PR DESCRIPTION
@naushir @RaspiShonak
There are 3 commits here:

- The first replaces the individual stream pointers in the app by a map (Naush suggested this a little while back, I think).
- The second adds a "lo res" stream to the viewfinder and video use cases.
- The final commit amends the face detect stage to use the low resolution stream so as to avoid the resize, but you do have to add something like `--lores-width 640 --lores-height 480` to the command line.