### PR TITLE
build: Use shared rather than static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set (CMAKE CXX_FLAGS "-Wall -Wextra -pedantic -Wno-unused-parameter -faligned-ne
 add_definitions(-Wfatal-errors)
 add_definitions(-Wno-psabi)
 add_definitions(-D_FILE_OFFSET_BITS=64)
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 IF (NOT ENABLE_COMPILE_FLAGS_FOR_TARGET)
     # On a Pi this will give us armhf or arm64.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,6 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 
 add_library(libcamera_app libcamera_app.cpp post_processing_stage.cpp post_processor.cpp)
 set_target_properties(libcamera_app PROPERTIES PREFIX "" IMPORT_PREFIX "")
-target_link_libraries(libcamera_app pthread images preview ${LIBCAMERA_LINK_LIBRARIES} ${Boost_LIBRARIES} -Wl,--whole-archive post_processing_stages -Wl,--no-whole-archive)
+target_link_libraries(libcamera_app pthread images preview ${LIBCAMERA_LINK_LIBRARIES} ${Boost_LIBRARIES} post_processing_stages)
 
 install(TARGETS libcamera_app LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/core/post_processing_stage.cpp
+++ b/core/post_processing_stage.cpp
@@ -41,13 +41,15 @@ void PostProcessingStage::Teardown()
 {
 }
 
-static std::map<std::string, StageCreateFunc> stages;
+static std::map<std::string, StageCreateFunc> *stages_ptr;
 std::map<std::string, StageCreateFunc> const &GetPostProcessingStages()
 {
-	return stages;
+	return *stages_ptr;
 }
 
 RegisterStage::RegisterStage(char const *name, StageCreateFunc create_func)
 {
+	static std::map<std::string, StageCreateFunc> stages;
+	stages_ptr = &stages;
 	stages[std::string(name)] = create_func;
 }


### PR DESCRIPTION
A small tweak is required in post_processing_stage.cpp to ensure the
"stages" table is initialised before anyone tries to put anything in
it.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>