### PR TITLE
Limit viewfinder image size by the preview window capabilities

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -144,6 +144,16 @@ void LibcameraApp::ConfigureViewfinder()
 			std::cout << "Viewfinder size chosen is " << size.toString() << std::endl;
 	}
 
+	// Finally trim the image size to the largest that the preview can handle.
+	Size max_size;
+	preview_->MaxImageSize(max_size.width, max_size.height);
+	if (max_size.width && max_size.height)
+	{
+		size.boundTo(max_size.boundedToAspectRatio(size)).alignDownTo(2, 2);
+		if (options_->verbose)
+			std::cout << "Final viewfinder size is " << size.toString() << std::endl;
+	}
+
 	// Now we get to override any of the default settings from the options_->
 	configuration_->at(0).pixelFormat = libcamera::formats::YUV420;
 	configuration_->at(0).size = size;

--- a/preview/drm_preview.cpp
+++ b/preview/drm_preview.cpp
@@ -24,6 +24,12 @@ public:
 	// Reset the preview window, clearing the current buffers and being ready to
 	// show new ones.
 	virtual void Reset() override;
+	// Return the maximum image size allowed.
+	virtual void MaxImageSize(unsigned int &w, unsigned int &h) const override
+	{
+		w = max_image_width_;
+		h = max_image_height_;
+	}
 
 private:
 	struct Buffer
@@ -54,6 +60,8 @@ private:
 	unsigned int screen_height_;
 	std::map<int, Buffer> buffers_; // map the DMABUF's fd to the Buffer
 	int last_fd_;
+	unsigned int max_image_width_;
+	unsigned int max_image_height_;
 };
 
 #define ERRSTR strerror(errno)
@@ -67,6 +75,9 @@ void DrmPreview::findCrtc()
 
 	if (res->count_crtcs <= 0)
 		throw std::runtime_error("drm: no crts");
+
+	max_image_width_ = res->max_width;
+	max_image_height_ = res->max_height;
 
 	if (!conId_)
 	{

--- a/preview/null_preview.cpp
+++ b/preview/null_preview.cpp
@@ -24,6 +24,8 @@ public:
 	// Reset the preview window, clearing the current buffers and being ready to
 	// show new ones.
 	void Reset() override {}
+	// Return the maximum image size allowed. Zeroes mean "no limit".
+	virtual void MaxImageSize(unsigned int &w, unsigned int &h) const override { w = h = 0; }
 
 private:
 };

--- a/preview/preview.hpp
+++ b/preview/preview.hpp
@@ -31,6 +31,8 @@ public:
 	virtual void Reset() = 0;
 	// Check if preview window has been shut down.
 	virtual bool Quit() { return false; }
+	// Return the maximum image size allowed.
+	virtual void MaxImageSize(unsigned int &w, unsigned int &h) const = 0;
 
 protected:
 	DoneCallback done_callback_;


### PR DESCRIPTION
Some devices can only render limited size images into the preview
window (for Pi 3, this limit is 2048x2048). We now fetch these limits,
and ensure that the viewfinder mode doesn't request anything larger
from the camera/ISP.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>