### PR TITLE
libcamera-still: Add option for immediate capture

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -169,7 +169,10 @@ static void event_loop(LibcameraStillApp &app)
 		still_flags |= LibcameraApp::FLAG_STILL_RAW;
 
 	app.OpenCamera();
-	app.ConfigureViewfinder();
+	if (options->immediate)
+		app.ConfigureStill(still_flags);
+	else
+		app.ConfigureViewfinder();
 	app.StartCamera();
 	app.SetPreviewDoneCallback(std::bind(&LibcameraApp::QueueRequest, &app, _1));
 	auto start_time = std::chrono::high_resolution_clock::now();

--- a/core/still_options.hpp
+++ b/core/still_options.hpp
@@ -43,6 +43,8 @@ struct StillOptions : public Options
 			 "Also save raw file in DNG format")
 			("latest", value<std::string>(&latest),
 			 "Create a symbolic link with this name to most recent saved file")
+			("immediate", value<bool>(&immediate)->default_value(false)->implicit_value(true),
+			 "Perform first capture immediately, with no preview phase")
 			;
 	}
 
@@ -60,6 +62,7 @@ struct StillOptions : public Options
 	std::string encoding;
 	bool raw;
 	std::string latest;
+	bool immediate;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{
@@ -100,6 +103,7 @@ struct StillOptions : public Options
 		std::cout << "    thumbnail height: " << thumb_height << std::endl;
 		std::cout << "    thumbnail quality: " << thumb_quality << std::endl;
 		std::cout << "    latest: " << latest << std::endl;
+		std::cout << "    immediate " << immediate << std::endl;
 		for (auto &s : exif)
 			std::cout << "    EXIF: " << s << std::endl;
 	}


### PR DESCRIPTION
The "immediate" option causes libcamera-still to capture the very
first frame from the camera, with no initial preview phase at all.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>