### PR TITLE
build: fix compiler error and warnings with GCC 10

### DIFF
--- a/core/post_processing_stage.hpp
+++ b/core/post_processing_stage.hpp
@@ -5,7 +5,11 @@
  * post_processing_stage.hpp - Post processing stage base class definition.
  */
 
+#include <map>
 #include <string>
+
+// Prevents compiler warnings in Boost headers with more recent versions of GCC.
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>


### PR DESCRIPTION
Two small fix-ups to prevent one failure and some Boost warnings when
building with GCC 10.3.0. Harmless with earlier versions.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>