### PR TITLE
libcamera_app: Consolidate move operations

### DIFF
--- a/core/completed_request.hpp
+++ b/core/completed_request.hpp
@@ -19,6 +19,16 @@ struct CompletedRequest
 
 	CompletedRequest() {}
 
+	// Mark CompletedRequest as non-copyable.
+	CompletedRequest(const CompletedRequest &c) = delete;
+	CompletedRequest(CompletedRequest &c) = delete;
+	CompletedRequest &operator=(CompletedRequest &c) = delete;
+	CompletedRequest &operator=(const CompletedRequest &c) = delete;
+
+	// But allow it to be movable.
+	CompletedRequest(CompletedRequest &&c) = default;
+	CompletedRequest &operator=(CompletedRequest &&c) = default;
+
 	CompletedRequest(unsigned int seq, BufferMap const &b, ControlList const &m)
 		: sequence(seq), buffers(b), metadata(m)
 	{

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -476,7 +476,7 @@ void LibcameraApp::QueueRequest(CompletedRequest const &completed_request)
 
 void LibcameraApp::PostMessage(MsgType &t, MsgPayload &p)
 {
-	msg_queue_.Post(Msg(t, p));
+	msg_queue_.Post(Msg(t, std::move(p)));
 }
 
 libcamera::Stream *LibcameraApp::GetStream(std::string const &name, int *w, int *h, int *stride) const

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -159,10 +159,7 @@ private:
 	struct PreviewItem
 	{
 		PreviewItem() : stream(nullptr) {}
-		template <typename T>
-		PreviewItem(T b, Stream *s) : completed_request(std::forward<T>(b)), stream(s)
-		{
-		}
+		PreviewItem(CompletedRequest &&b, Stream *s) : completed_request(std::move(b)), stream(s) {}
 		PreviewItem &operator=(PreviewItem &&other)
 		{
 			completed_request = std::move(other.completed_request);

--- a/core/metadata.hpp
+++ b/core/metadata.hpp
@@ -35,7 +35,7 @@ public:
 	void Set(std::string const &tag, T &&value)
 	{
 		std::scoped_lock lock(mutex_);
-		data_.insert_or_assign(tag, value);
+		data_.insert_or_assign(tag, std::forward<T>(value));
 	}
 
 	template <typename T>


### PR DESCRIPTION
Mark CompletedRequest as non-movable.
Fixup Metadata::Set() forwarding the metadata value correctly.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>