### PR TITLE
core: Fix unsafe memory access in ConfigureStill

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -170,8 +170,9 @@ void LibcameraApp::ConfigureStill(unsigned int flags)
 		std::cout << "Configuring still capture..." << std::endl;
 
 	// Will add a raw capture stream once that works properly.
+	bool have_raw_stream = flags & FLAG_STILL_RAW;
 	StreamRoles stream_roles;
-	if (flags & FLAG_STILL_RAW)
+	if (have_raw_stream)
 		stream_roles = { StreamRole::StillCapture, StreamRole::Raw };
 	else
 		stream_roles = { StreamRole::StillCapture };
@@ -198,7 +199,7 @@ void LibcameraApp::ConfigureStill(unsigned int flags)
 
 	post_processor_.AdjustConfig("still", &configuration_->at(0));
 
-	if ((flags & FLAG_STILL_RAW) && !options_->rawfull)
+	if (have_raw_stream && !options_->rawfull)
 	{
 		configuration_->at(1).size.width = configuration_->at(0).size.width;
 		configuration_->at(1).size.height = configuration_->at(0).size.height;
@@ -209,7 +210,8 @@ void LibcameraApp::ConfigureStill(unsigned int flags)
 	setupCapture();
 
 	streams_["still"] = configuration_->at(0).stream();
-	streams_["raw"] = configuration_->at(1).stream();
+	if (have_raw_stream)
+		streams_["raw"] = configuration_->at(1).stream();
 
 	post_processor_.Configure();
 


### PR DESCRIPTION
It wasn't checking that the raw stream existed before accessing it.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>