### PR TITLE
Use shared_ptr to pass CompletedRequests around

### DIFF
--- a/apps/libcamera_hello.cpp
+++ b/apps/libcamera_hello.cpp
@@ -21,8 +21,7 @@ static void event_loop(LibcameraApp &app)
 	app.OpenCamera();
 	app.ConfigureViewfinder();
 	app.StartCamera();
-	// When the preview window is done with a set of buffers, queue them back to libcamera.
-	app.SetPreviewDoneCallback(std::bind(&LibcameraApp::QueueRequest, &app, _1));
+
 	auto start_time = std::chrono::high_resolution_clock::now();
 
 	for (unsigned int count = 0; ; count++)
@@ -39,7 +38,7 @@ static void event_loop(LibcameraApp &app)
 		if (options->timeout && now - start_time > std::chrono::milliseconds(options->timeout))
 			return;
 
-		CompletedRequest &completed_request = std::get<CompletedRequest>(msg.payload);
+		CompletedRequestPtr &completed_request = std::get<CompletedRequestPtr>(msg.payload);
 		app.ShowPreview(completed_request, app.ViewfinderStream());
 	}
 }

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -40,7 +40,6 @@ static void event_loop(LibcameraJpegApp &app)
 	app.OpenCamera();
 	app.ConfigureViewfinder();
 	app.StartCamera();
-	app.SetPreviewDoneCallback(std::bind(&LibcameraApp::QueueRequest, &app, _1));
 	auto start_time = std::chrono::high_resolution_clock::now();
 
 	for (unsigned int count = 0; ; count++)
@@ -65,7 +64,7 @@ static void event_loop(LibcameraJpegApp &app)
 			}
 			else
 			{
-				CompletedRequest &completed_request = std::get<CompletedRequest>(msg.payload);
+				CompletedRequestPtr &completed_request = std::get<CompletedRequestPtr>(msg.payload);
 				app.ShowPreview(completed_request, app.ViewfinderStream());
 			}
 		}
@@ -78,9 +77,9 @@ static void event_loop(LibcameraJpegApp &app)
 			unsigned int w, h, stride;
 			Stream *stream = app.StillStream();
 			app.StreamDimensions(stream, &w, &h, &stride);
-			CompletedRequest &payload = std::get<CompletedRequest>(msg.payload);
-			const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(payload.buffers[stream]);
-			jpeg_save(mem, w, h, stride, stream->configuration().pixelFormat, payload.metadata, options->output,
+			CompletedRequestPtr &payload = std::get<CompletedRequestPtr>(msg.payload);
+			const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(payload->buffers[stream]);
+			jpeg_save(mem, w, h, stride, stream->configuration().pixelFormat, payload->metadata, options->output,
 					  app.CameraId(), options);
 			return;
 		}

--- a/apps/libcamera_raw.cpp
+++ b/apps/libcamera_raw.cpp
@@ -29,7 +29,6 @@ static void event_loop(LibcameraRaw &app)
 {
 	VideoOptions const *options = app.GetOptions();
 	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
-	app.SetEncodeBufferDoneCallback(std::bind(&LibcameraRaw::QueueRequest, &app, _1));
 	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
 	app.StartEncoder();
 
@@ -61,7 +60,7 @@ static void event_loop(LibcameraRaw &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload), app.RawStream());
+		app.EncodeBuffer(std::get<CompletedRequestPtr>(msg.payload), app.RawStream());
 	}
 }
 

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -55,12 +55,10 @@ static void event_loop(LibcameraEncoder &app)
 {
 	VideoOptions const *options = app.GetOptions();
 	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
-	app.SetEncodeBufferDoneCallback(std::bind(&LibcameraEncoder::ShowPreview, &app, _1, _2));
 	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
 	app.StartEncoder();
 
 	app.OpenCamera();
-	app.SetPreviewDoneCallback(std::bind(&LibcameraEncoder::QueueRequest, &app, _1));
 	app.ConfigureVideo();
 	app.StartCamera();
 	auto start_time = std::chrono::high_resolution_clock::now();
@@ -92,7 +90,9 @@ static void event_loop(LibcameraEncoder &app)
 			return;
 		}
 
-		app.EncodeBuffer(std::get<CompletedRequest>(msg.payload), app.VideoStream());
+		CompletedRequestPtr &completed_request = std::get<CompletedRequestPtr>(msg.payload);
+		app.EncodeBuffer(completed_request, app.VideoStream());
+		app.ShowPreview(completed_request, app.VideoStream());
 	}
 }
 

--- a/core/completed_request.hpp
+++ b/core/completed_request.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <libcamera/controls.h>
 #include <libcamera/request.h>
 
@@ -16,17 +18,6 @@ struct CompletedRequest
 {
 	using BufferMap = libcamera::Request::BufferMap;
 	using ControlList = libcamera::ControlList;
-
-	CompletedRequest() {}
-
-	// Mark CompletedRequest as non-copyable.
-	CompletedRequest(const CompletedRequest &c) = delete;
-	CompletedRequest &operator=(CompletedRequest &c) = delete;
-	CompletedRequest &operator=(const CompletedRequest &c) = delete;
-
-	// But allow it to be movable.
-	CompletedRequest(CompletedRequest &&c) = default;
-	CompletedRequest &operator=(CompletedRequest &&c) = default;
 
 	CompletedRequest(unsigned int seq, BufferMap const &b, ControlList const &m)
 		: sequence(seq), buffers(b), metadata(m)
@@ -38,3 +29,5 @@ struct CompletedRequest
 	float framerate;
 	Metadata post_process_metadata;
 };
+
+using CompletedRequestPtr = std::shared_ptr<CompletedRequest>;

--- a/core/post_processor.hpp
+++ b/core/post_processor.hpp
@@ -24,7 +24,7 @@ class LibcameraApp;
 
 using namespace std::chrono_literals;
 class PostProcessingStage;
-using PostProcessorCallback = std::function<void(CompletedRequest &)>;
+using PostProcessorCallback = std::function<void(CompletedRequestPtr &)>;
 using StreamConfiguration = libcamera::StreamConfiguration;
 typedef std::unique_ptr<PostProcessingStage> StagePtr;
 
@@ -45,7 +45,7 @@ public:
 
 	void Start();
 
-	void Process(CompletedRequest &request);
+	void Process(CompletedRequestPtr &request);
 
 	void Stop();
 
@@ -58,7 +58,7 @@ private:
 	std::vector<StagePtr> stages_;
 	void outputThread();
 
-	std::queue<CompletedRequest> requests_;
+	std::queue<CompletedRequestPtr> requests_;
 	std::queue<std::future<bool>> futures_;
 	std::thread output_thread_;
 	bool quit_;

--- a/post_processing_stages/annotate_cv_stage.cpp
+++ b/post_processing_stages/annotate_cv_stage.cpp
@@ -32,7 +32,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	Stream *stream_;
@@ -78,14 +78,14 @@ void AnnotateCvStage::Configure()
 	adjusted_thickness_ = std::max(thickness_ * width_ / 700, 1u);
 }
 
-bool AnnotateCvStage::Process(CompletedRequest &completed_request)
+bool AnnotateCvStage::Process(CompletedRequestPtr &completed_request)
 {
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
-	FrameInfo info(completed_request.metadata);
-	info.sequence = completed_request.sequence;
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
+	FrameInfo info(completed_request->metadata);
+	info.sequence = completed_request->sequence;
 
 	// Other post-processing stages can supply metadata to update the text.
-	completed_request.post_process_metadata.Get("annotate.text", text_);
+	completed_request->post_process_metadata.Get("annotate.text", text_);
 	std::string text = info.ToString(text_);
 
 	uint8_t *ptr = (uint8_t *)buffer.data();

--- a/post_processing_stages/hdr_stage.cpp
+++ b/post_processing_stages/hdr_stage.cpp
@@ -382,7 +382,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	Stream *stream_;
@@ -455,7 +455,7 @@ void HdrStage::Configure()
 	lp_ = HdrImage(width_, height_, width_ * height_);
 }
 
-bool HdrStage::Process(CompletedRequest &completed_request)
+bool HdrStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!stream_)
 		return false; // in viewfinder mode, do nothing
@@ -467,7 +467,7 @@ bool HdrStage::Process(CompletedRequest &completed_request)
 	if (frame_num_ >= config_.num_frames)
 		return false;
 
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint8_t *image = buffer.data();
 
 	// Accumulate frame.

--- a/post_processing_stages/motion_detect_stage.cpp
+++ b/post_processing_stages/motion_detect_stage.cpp
@@ -39,7 +39,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	// In the Config, dimensions are given as fractions of the lores image size.
@@ -125,15 +125,15 @@ void MotionDetectStage::Configure()
 	motion_detected_ = false;
 }
 
-bool MotionDetectStage::Process(CompletedRequest &completed_request)
+bool MotionDetectStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!stream_)
 		return false;
 
-	if (config_.frame_period && completed_request.sequence % config_.frame_period)
+	if (config_.frame_period && completed_request->sequence % config_.frame_period)
 		return false;
 
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint8_t *image = buffer.data();
 
 	// We need to protect access to first_time_, previous_frame_ and motion_detected_.
@@ -150,7 +150,7 @@ bool MotionDetectStage::Process(CompletedRequest &completed_request)
 				*(old_value_ptr++) = *new_value_ptr;
 		}
 
-		completed_request.post_process_metadata.Set("motion_detect.result", motion_detected_);
+		completed_request->post_process_metadata.Set("motion_detect.result", motion_detected_);
 
 		return false;
 	}
@@ -178,7 +178,7 @@ bool MotionDetectStage::Process(CompletedRequest &completed_request)
 		std::cerr << "Motion " << (motion_detected ? "detected" : "stopped") << std::endl;
 
 	motion_detected_ = motion_detected;
-	completed_request.post_process_metadata.Set("motion_detect.result", motion_detected);
+	completed_request->post_process_metadata.Set("motion_detect.result", motion_detected);
 
 	return false;
 }

--- a/post_processing_stages/negate_stage.cpp
+++ b/post_processing_stages/negate_stage.cpp
@@ -24,7 +24,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	Stream *stream_;
@@ -42,9 +42,9 @@ void NegateStage::Configure()
 	stream_ = app_->GetMainStream();
 }
 
-bool NegateStage::Process(CompletedRequest &completed_request)
+bool NegateStage::Process(CompletedRequestPtr &completed_request)
 {
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint32_t *ptr = (uint32_t *)buffer.data();
 
 	// Constraints on the stride mean we always have multiple-of-4 bytes.

--- a/post_processing_stages/object_classify_tf_stage.cpp
+++ b/post_processing_stages/object_classify_tf_stage.cpp
@@ -39,7 +39,7 @@ protected:
 
 	// Attach the results as metadata; optionally write the labels too for the annotate_cv
 	// stage to pick up.
-	void applyResults(CompletedRequest &completed_request) override;
+	void applyResults(CompletedRequestPtr &completed_request) override;
 
 private:
 	void readLabelsFile(const std::string &file_name);
@@ -86,9 +86,9 @@ void ObjectClassifyTfStage::readLabelsFile(const std::string &file_name)
 		labels_.emplace_back();
 }
 
-void ObjectClassifyTfStage::applyResults(CompletedRequest &completed_request)
+void ObjectClassifyTfStage::applyResults(CompletedRequestPtr &completed_request)
 {
-	completed_request.post_process_metadata.Set("object_classify.results", output_results_);
+	completed_request->post_process_metadata.Set("object_classify.results", output_results_);
 
 	if (config()->display_labels)
 	{
@@ -109,7 +109,7 @@ void ObjectClassifyTfStage::applyResults(CompletedRequest &completed_request)
 			first = false;
 		}
 
-		completed_request.post_process_metadata.Set("annotate.text", annotation.str());
+		completed_request->post_process_metadata.Set("annotate.text", annotation.str());
 	}
 }
 

--- a/post_processing_stages/object_detect_draw_cv_stage.cpp
+++ b/post_processing_stages/object_detect_draw_cv_stage.cpp
@@ -29,7 +29,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	Stream *stream_;
@@ -56,19 +56,19 @@ void ObjectDetectDrawCvStage::Read(boost::property_tree::ptree const &params)
 	font_size_ = params.get<double>("font_size", 1.0);
 }
 
-bool ObjectDetectDrawCvStage::Process(CompletedRequest &completed_request)
+bool ObjectDetectDrawCvStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!stream_)
 		return false;
 
 	unsigned int w, h, stride;
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint32_t *ptr = (uint32_t *)buffer.data();
 	app_->StreamDimensions(stream_, &w, &h, &stride);
 
 	std::vector<Detection> detections;
 
-	completed_request.post_process_metadata.Get("object_detect.results", detections);
+	completed_request->post_process_metadata.Get("object_detect.results", detections);
 
 	Mat image(h, w, CV_8U, ptr, stride);
 	Scalar colour = Scalar(255, 255, 255);

--- a/post_processing_stages/object_detect_tf_stage.cpp
+++ b/post_processing_stages/object_detect_tf_stage.cpp
@@ -44,7 +44,7 @@ protected:
 
 	// Attach the results as metadata; optionally write the labels too for the annotate_cv
 	// stage to pick up.
-	void applyResults(CompletedRequest &completed_request) override;
+	void applyResults(CompletedRequestPtr &completed_request) override;
 
 private:
 	void readLabelsFile(const std::string &file_name);
@@ -92,9 +92,9 @@ void ObjectDetectTfStage::checkConfiguration()
 		throw std::runtime_error("ObjectDetectTfStage: Main stream is required");
 }
 
-void ObjectDetectTfStage::applyResults(CompletedRequest &completed_request)
+void ObjectDetectTfStage::applyResults(CompletedRequestPtr &completed_request)
 {
-	completed_request.post_process_metadata.Set("object_detect.results", output_results_);
+	completed_request->post_process_metadata.Set("object_detect.results", output_results_);
 }
 
 static unsigned int area(const Rectangle &r)

--- a/post_processing_stages/plot_pose_cv_stage.cpp
+++ b/post_processing_stages/plot_pose_cv_stage.cpp
@@ -59,7 +59,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	void drawFeatures(cv::Mat &img, std::vector<Point> locations, std::vector<float> confidences);
@@ -85,13 +85,13 @@ void PlotPoseCvStage::Read(boost::property_tree::ptree const &params)
 	confidence_threshold_ = params.get<float>("confidence_threshold", -1.0);
 }
 
-bool PlotPoseCvStage::Process(CompletedRequest &completed_request)
+bool PlotPoseCvStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!stream_)
 		return false;
 
 	unsigned int w, h, stride;
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint32_t *ptr = (uint32_t *)buffer.data();
 	app_->StreamDimensions(stream_, &w, &h, &stride);
 
@@ -100,8 +100,8 @@ bool PlotPoseCvStage::Process(CompletedRequest &completed_request)
 	std::vector<Point> cv_locations;
 	std::vector<float> confidences;
 
-	completed_request.post_process_metadata.Get("pose_estimation.locations", lib_locations);
-	completed_request.post_process_metadata.Get("pose_estimation.confidences", confidences);
+	completed_request->post_process_metadata.Get("pose_estimation.locations", lib_locations);
+	completed_request->post_process_metadata.Get("pose_estimation.confidences", confidences);
 
 	if (!confidences.empty() && !lib_locations.empty())
 	{

--- a/post_processing_stages/pose_estimation_tf_stage.cpp
+++ b/post_processing_stages/pose_estimation_tf_stage.cpp
@@ -28,7 +28,7 @@ protected:
 	void interpretOutputs() override;
 
 	// Attach results as metadata.
-	void applyResults(CompletedRequest &completed_request) override;
+	void applyResults(CompletedRequestPtr &completed_request) override;
 
 private:
 	std::vector<libcamera::Point> heats_;
@@ -53,10 +53,10 @@ void PoseEstimationTfStage::checkConfiguration()
 		throw std::runtime_error("PoseEstimationTfStage: Main stream is required");
 }
 
-void PoseEstimationTfStage::applyResults(CompletedRequest &completed_request)
+void PoseEstimationTfStage::applyResults(CompletedRequestPtr &completed_request)
 {
-	completed_request.post_process_metadata.Set("pose_estimation.locations", locations_);
-	completed_request.post_process_metadata.Set("pose_estimation.confidences", confidences_);
+	completed_request->post_process_metadata.Set("pose_estimation.locations", locations_);
+	completed_request->post_process_metadata.Set("pose_estimation.confidences", confidences_);
 }
 
 void PoseEstimationTfStage::interpretOutputs()

--- a/post_processing_stages/post_processing_stage.hpp
+++ b/post_processing_stages/post_processing_stage.hpp
@@ -5,6 +5,7 @@
  * post_processing_stage.hpp - Post processing stage base class definition.
  */
 
+#include <chrono>
 #include <map>
 #include <string>
 
@@ -13,14 +14,14 @@
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
-#include <chrono>
+
+#include "core/completed_request.hpp"
 
 namespace libcamera
 {
 struct StreamConfiguration;
 }
 
-struct CompletedRequest;
 class LibcameraApp;
 
 using StreamConfiguration = libcamera::StreamConfiguration;
@@ -43,7 +44,7 @@ public:
 	virtual void Start();
 
 	// Return true if this request is to be dropped.
-	virtual bool Process(CompletedRequest &completed_request) = 0;
+	virtual bool Process(CompletedRequestPtr &completed_request) = 0;
 
 	virtual void Stop();
 

--- a/post_processing_stages/segmentation_tf_stage.cpp
+++ b/post_processing_stages/segmentation_tf_stage.cpp
@@ -41,7 +41,7 @@ protected:
 	void interpretOutputs() override;
 
 	// Add metadata and optionally draw the segmentation in the corner of the image.
-	void applyResults(CompletedRequest &completed_request) override;
+	void applyResults(CompletedRequestPtr &completed_request) override;
 
 	void readLabelsFile(const std::string &filename);
 
@@ -81,17 +81,17 @@ void SegmentationTfStage::checkConfiguration()
 		throw std::runtime_error("SegmentationTfStage: Main stream is required for drawing");
 }
 
-void SegmentationTfStage::applyResults(CompletedRequest &completed_request)
+void SegmentationTfStage::applyResults(CompletedRequestPtr &completed_request)
 {
 	// Store the segmentation in image metadata.
-	completed_request.post_process_metadata.Set("segmentation.result",
+	completed_request->post_process_metadata.Set("segmentation.result",
 												Segmentation(WIDTH, HEIGHT, labels_, segmentation_));
 
 	// Optionally, draw the segmentation in the bottom right corner of the main image.
 	if (!config()->draw)
 		return;
 
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[main_stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[main_stream_])[0];
 	int y_offset = main_h_ - HEIGHT;
 	int x_offset = main_w_ - WIDTH;
 	int scale = 255 / labels_.size();

--- a/post_processing_stages/sobel_cv_stage.cpp
+++ b/post_processing_stages/sobel_cv_stage.cpp
@@ -29,7 +29,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 private:
 	Stream *stream_;
@@ -55,11 +55,11 @@ void SobelCvStage::Configure()
 		throw std::runtime_error("SobelCvStage: only YUV420 format supported");
 }
 
-bool SobelCvStage::Process(CompletedRequest &completed_request)
+bool SobelCvStage::Process(CompletedRequestPtr &completed_request)
 {
 	unsigned int w, h, stride;
 	app_->StreamDimensions(stream_, &w, &h, &stride);
-	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
+	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[stream_])[0];
 	uint8_t *ptr = (uint8_t *)buffer.data();
 
 	//Everything beyond this point is image processing...

--- a/post_processing_stages/tf_stage.cpp
+++ b/post_processing_stages/tf_stage.cpp
@@ -93,17 +93,17 @@ void TfStage::Configure()
 	checkConfiguration();
 }
 
-bool TfStage::Process(CompletedRequest &completed_request)
+bool TfStage::Process(CompletedRequestPtr &completed_request)
 {
 	if (!lores_stream_)
 		return false;
 
 	{
 		std::unique_lock<std::mutex> lck(future_mutex_);
-		if (config_->refresh_rate && completed_request.sequence % config_->refresh_rate == 0 &&
+		if (config_->refresh_rate && completed_request->sequence % config_->refresh_rate == 0 &&
 			(!future_ || future_->wait_for(std::chrono::seconds(0)) == std::future_status::ready))
 		{
-			libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[lores_stream_])[0];
+			libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request->buffers[lores_stream_])[0];
 
 			// Copy the lores image here and let the asynchronous thread convert it to RGB.
 			// Doing the "extra" copy is in fact hugely beneficial because it turns uncacned

--- a/post_processing_stages/tf_stage.hpp
+++ b/post_processing_stages/tf_stage.hpp
@@ -52,7 +52,7 @@ public:
 
 	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request) override;
+	bool Process(CompletedRequestPtr &completed_request) override;
 
 	void Stop() override;
 
@@ -76,7 +76,7 @@ protected:
 	// Here we run synchronously again and so should not take too long. The results
 	// produced by interpretOutputs can be used now, for example as metadata to attach
 	// to the image, or even drawn onto the image itself.
-	virtual void applyResults(CompletedRequest &completed_request) {}
+	virtual void applyResults(CompletedRequestPtr &completed_request) {}
 
 	std::unique_ptr<TfConfig> config_;
 


### PR DESCRIPTION
Unfortunately this is one big all-or-nothing change. There's a lot of
mundane CompletedRequest -> CompletedRequestPtr changes here, but some
are more significant.

* The shared_ptr has a custom deleter so that once all references to
  it are dropped it calls LibcameraApp::queueRequest for
  recycling. (There's a nasty corner case about a CompletedRequest
  being recycled once the camera has been stopped and restarted.)

* LibcameraApp::ShowPreview needs to take a reference to the shared_ptr.

* LibcameraEncoder::EncodeBuffer needs to take a reference to the
  shared_ptr.

* The post-processor can re-use the shared_ptr both when it receives
  the CompletedRequest, and when it gets passed on to the message
  queue for the application.

* Neither the encoder nor the preview need a callback anymore to pass
  the buffer on (and ultimately ensure that LibcameraApp::QueueRequest
  is called, as this now happens automagically).

In general, I've tried to re-use references (by moving the shared_ptr)
wherever it's appropriate.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>