### PR TITLE
Fix compiler warnings.

### DIFF
--- a/.github/workflows/libcamera-apps-test.yml
+++ b/.github/workflows/libcamera-apps-test.yml
@@ -10,6 +10,7 @@ env:
   NUM_JOBS: 4
   GCC_COMPILER: "-DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++"
   CLANG_COMPILER: "-DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++"
+  CMAKE_OTHER_FLAGS: "-DENABLE_TFLITE=1"
 
 jobs:
   build-test-gcc:
@@ -23,7 +24,7 @@ jobs:
         clean: true
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{env.GCC_COMPILER}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{env.GCC_COMPILER}} ${{env.CMAKE_OTHER_FLAGS}}
       timeout-minutes: 5
 
     - name: Build
@@ -51,7 +52,7 @@ jobs:
         clean: true
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{env.CLANG_COMPILER}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{env.CLANG_COMPILER}} ${{env.CMAKE_OTHER_FLAGS}}
       timeout-minutes: 5
 
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,15 @@ endif()
 
 set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set (CMAKE_CXX_STANDARD 17)
-set (CMAKE CXX_FLAGS "-Wall -Wextra -pedantic -Wno-unused-parameter -faligned-new")
+set (CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-unused-parameter -faligned-new")
+add_definitions(-Werror)
 add_definitions(-Wfatal-errors)
-add_definitions(-Wno-psabi)
 add_definitions(-D_FILE_OFFSET_BITS=64)
+
+if (CMAKE_COMPILER_IS_GNUCXX)
+    add_definitions(-Wno-psabi)
+endif()
+
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
 IF (NOT ENABLE_COMPILE_FLAGS_FOR_TARGET)

--- a/apps/libcamera_detect.cpp
+++ b/apps/libcamera_detect.cpp
@@ -43,7 +43,7 @@ public:
 };
 
 // In jpeg.cpp:
-void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			   libcamera::PixelFormat const &pixel_format, libcamera::ControlList const &metadata,
 			   std::string const &filename, std::string const &cam_name, StillOptions const *options);
 
@@ -99,7 +99,7 @@ static void event_loop(LibcameraDetectApp &app)
 			app.StopCamera();
 			last_capture_frame = completed_request.sequence;
 
-			int w, h, stride;
+			unsigned int w, h, stride;
 			libcamera::Stream *stream = app.StillStream(&w, &h, &stride);
 			const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(completed_request.buffers[stream]);
 

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -28,7 +28,7 @@ public:
 };
 
 // In jpeg.cpp:
-void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			   libcamera::PixelFormat const &pixel_format, libcamera::ControlList const &metadata,
 			   std::string const &filename, std::string const &cam_name, StillOptions const *options);
 
@@ -75,7 +75,7 @@ static void event_loop(LibcameraJpegApp &app)
 			app.StopCamera();
 			std::cout << "Still capture image received" << std::endl;
 
-			int w, h, stride;
+			unsigned int w, h, stride;
 			Stream *stream = app.StillStream();
 			app.StreamDimensions(stream, &w, &h, &stride);
 			CompletedRequest &payload = std::get<CompletedRequest>(msg.payload);

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -181,7 +181,7 @@ static void event_loop(LibcameraStillApp &app)
 	// Monitoring for keypresses and signals.
 	signal(SIGUSR1, default_signal_handler);
 	signal(SIGUSR2, default_signal_handler);
-	pollfd p[1] = { { STDIN_FILENO, POLLIN } };
+	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
 
 	for (unsigned int count = 0; ; count++)
 	{

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -27,25 +27,25 @@ public:
 };
 
 // In jpeg.cpp:
-void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			   libcamera::PixelFormat const &pixel_format, libcamera::ControlList const &metadata,
 			   std::string const &filename, std::string const &cam_name, StillOptions const *options);
 
 // In yuv.cpp:
-void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options);
 
 // In dng.cpp:
-void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, libcamera::ControlList const &metadata,
 			  std::string const &filename, std::string const &cam_name, StillOptions const *options);
 
 // In png.cpp:
-void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options);
 
 // In bmp.cpp:
-void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options);
 
 static std::string generate_filename(StillOptions const *options)
@@ -89,7 +89,7 @@ static void update_latest_link(std::string const &filename, StillOptions const *
 static void save_image(LibcameraStillApp &app, CompletedRequest &payload, Stream *stream, std::string const &filename)
 {
 	StillOptions const *options = app.GetOptions();
-	int w, h, stride;
+	unsigned int w, h, stride;
 	app.StreamDimensions(stream, &w, &h, &stride);
 	libcamera::PixelFormat const &pixel_format = stream->configuration().pixelFormat;
 	const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(payload.buffers[stream]);

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -68,7 +68,7 @@ static void event_loop(LibcameraEncoder &app)
 	// Monitoring for keypresses and signals.
 	signal(SIGUSR1, default_signal_handler);
 	signal(SIGUSR2, default_signal_handler);
-	pollfd p[1] = { { STDIN_FILENO, POLLIN } };
+	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
 
 	for (unsigned int count = 0; ; count++)
 	{

--- a/core/frame_info.hpp
+++ b/core/frame_info.hpp
@@ -42,7 +42,7 @@ struct FrameInfo
 	{
 		std::string parsed(info_string);
 
-		for (auto const t : tokens)
+		for (auto const &t : tokens)
 		{
 			std::size_t pos = parsed.find(t);
 			if (pos != std::string::npos)

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -481,7 +481,8 @@ void LibcameraApp::PostMessage(MsgType &t, MsgPayload &p)
 	msg_queue_.Post(Msg(t, std::move(p)));
 }
 
-libcamera::Stream *LibcameraApp::GetStream(std::string const &name, int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::GetStream(std::string const &name, unsigned int *w, unsigned int *h,
+										   unsigned int *stride) const
 {
 	auto it = streams_.find(name);
 	if (it == streams_.end())
@@ -490,27 +491,27 @@ libcamera::Stream *LibcameraApp::GetStream(std::string const &name, int *w, int 
 	return it->second;
 }
 
-libcamera::Stream *LibcameraApp::ViewfinderStream(int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::ViewfinderStream(unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	return GetStream("viewfinder", w, h, stride);
 }
 
-libcamera::Stream *LibcameraApp::StillStream(int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::StillStream(unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	return GetStream("still", w, h, stride);
 }
 
-libcamera::Stream *LibcameraApp::RawStream(int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::RawStream(unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	return GetStream("raw", w, h, stride);
 }
 
-libcamera::Stream *LibcameraApp::VideoStream(int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::VideoStream(unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	return GetStream("video", w, h, stride);
 }
 
-libcamera::Stream *LibcameraApp::LoresStream(int *w, int *h, int *stride) const
+libcamera::Stream *LibcameraApp::LoresStream(unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	return GetStream("lores", w, h, stride);
 }
@@ -563,7 +564,7 @@ void LibcameraApp::SetControls(ControlList &controls)
 	controls_ = std::move(controls);
 }
 
-void LibcameraApp::StreamDimensions(Stream const *stream, int *w, int *h, int *stride) const
+void LibcameraApp::StreamDimensions(Stream const *stream, unsigned int *w, unsigned int *h, unsigned int *stride) const
 {
 	StreamConfiguration const &cfg = stream->configuration();
 	if (w)
@@ -714,7 +715,7 @@ void LibcameraApp::previewThread()
 		if (item.stream->configuration().pixelFormat != libcamera::formats::YUV420)
 			throw std::runtime_error("Preview windows only support YUV420");
 
-		int w, h, stride;
+		unsigned int w, h, stride;
 		StreamDimensions(item.stream, &w, &h, &stride);
 		FrameBuffer *buffer = item.completed_request.buffers[item.stream];
 		libcamera::Span span = Mmap(buffer)[0];

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -30,7 +30,7 @@
 #include "core/completed_request.hpp"
 #include "core/post_processor.hpp"
 
-class Options;
+struct Options;
 class Preview;
 
 namespace controls = libcamera::controls;

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -106,12 +106,14 @@ public:
 	void QueueRequest(CompletedRequest const &completed_request);
 	void PostMessage(MsgType &t, MsgPayload &p);
 
-	Stream *GetStream(std::string const &name, int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
-	Stream *ViewfinderStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
-	Stream *StillStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
-	Stream *RawStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
-	Stream *VideoStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
-	Stream *LoresStream(int *w = nullptr, int *h = nullptr, int *stride = nullptr) const;
+	Stream *GetStream(std::string const &name, unsigned int *w = nullptr, unsigned int *h = nullptr,
+					  unsigned int *stride = nullptr) const;
+	Stream *ViewfinderStream(unsigned int *w = nullptr, unsigned int *h = nullptr,
+							 unsigned int *stride = nullptr) const;
+	Stream *StillStream(unsigned int *w = nullptr, unsigned int *h = nullptr, unsigned int *stride = nullptr) const;
+	Stream *RawStream(unsigned int *w = nullptr, unsigned int *h = nullptr, unsigned int *stride = nullptr) const;
+	Stream *VideoStream(unsigned int *w = nullptr, unsigned int *h = nullptr, unsigned int *stride = nullptr) const;
+	Stream *LoresStream(unsigned int *w = nullptr, unsigned int *h = nullptr, unsigned int *stride = nullptr) const;
 	Stream *GetMainStream() const;
 
 	std::vector<libcamera::Span<uint8_t>> Mmap(FrameBuffer *buffer) const;
@@ -120,7 +122,7 @@ public:
 	void ShowPreview(CompletedRequest &completed_request, Stream *stream);
 
 	void SetControls(ControlList &controls);
-	void StreamDimensions(Stream const *stream, int *w, int *h, int *stride) const;
+	void StreamDimensions(Stream const *stream, unsigned int *w, unsigned int *h, unsigned int *stride) const;
 
 protected:
 	std::unique_ptr<Options> options_;

--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -33,7 +33,7 @@ public:
 	void EncodeBuffer(CompletedRequest &completed_request, Stream *stream)
 	{
 		assert(encoder_);
-		int w, h, stride;
+		unsigned int w, h, stride;
 		StreamDimensions(stream, &w, &h, &stride);
 		FrameBuffer *buffer = completed_request.buffers[stream];
 		libcamera::Span span = Mmap(buffer)[0];

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -108,6 +108,8 @@ struct Options
 			;
 	}
 
+	virtual ~Options() {}
+
 	bool help;
 	bool version;
 	bool verbose;

--- a/core/post_processing_stage.hpp
+++ b/core/post_processing_stage.hpp
@@ -17,10 +17,10 @@
 
 namespace libcamera
 {
-class StreamConfiguration;
+struct StreamConfiguration;
 }
 
-class CompletedRequest;
+struct CompletedRequest;
 class LibcameraApp;
 
 using StreamConfiguration = libcamera::StreamConfiguration;

--- a/core/post_processor.cpp
+++ b/core/post_processor.cpp
@@ -106,7 +106,7 @@ void PostProcessor::Process(CompletedRequest &request)
 
 	// Queue the futures to ensure we have correct ordering in the output thread. The promise/future return value
 	// tells us when all the streams for this request have been processed and output_ready_callback_ can be called.
-	futures_.push(std::move(promise.get_future()));
+	futures_.push(promise.get_future());
 	std::thread { process_fn, std::ref(requests_.back()), std::move(promise) }.detach();
 }
 

--- a/core/post_processor.hpp
+++ b/core/post_processor.hpp
@@ -17,7 +17,7 @@
 
 namespace libcamera
 {
-class StreamConfiguration;
+struct StreamConfiguration;
 }
 
 class LibcameraApp;

--- a/encoder/encoder.hpp
+++ b/encoder/encoder.hpp
@@ -30,8 +30,8 @@ public:
 	void SetOutputReadyCallback(OutputReadyCallback callback) { output_ready_callback_ = callback; }
 	// Encode the given buffer. The buffer is specified both by an fd and size
 	// describing a DMABUF, and by a mmapped userland pointer.
-	virtual void EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride,
-							  int64_t timestamp_us) = 0;
+	virtual void EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height,
+							  unsigned int stride, int64_t timestamp_us) = 0;
 
 protected:
 	InputDoneCallback input_done_callback_;

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -193,7 +193,8 @@ H264Encoder::~H264Encoder()
 	// Other stuff will mostly get hoovered up with the process quits.
 }
 
-void H264Encoder::EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us)
+void H264Encoder::EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height,
+							   unsigned int stride, int64_t timestamp_us)
 {
 	int index;
 	{

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -17,7 +17,7 @@
 
 #include "h264_encoder.hpp"
 
-static int xioctl(int fd, int ctl, void *arg)
+static int xioctl(int fd, unsigned long ctl, void *arg)
 {
 	int ret, num_tries = 10;
 	do
@@ -134,7 +134,7 @@ H264Encoder::H264Encoder(VideoOptions const *options) : Encoder(options), abort_
 
 	// We have to maintain a list of the buffers we can use when our caller gives
 	// us another frame to encode.
-	for (int i = 0; i < reqbufs.count; i++)
+	for (unsigned int i = 0; i < reqbufs.count; i++)
 		input_buffers_available_.push(i);
 
 	reqbufs = {};
@@ -146,7 +146,7 @@ H264Encoder::H264Encoder(VideoOptions const *options) : Encoder(options), abort_
 	if (options->verbose)
 		std::cout << "Got " << reqbufs.count << " capture buffers" << std::endl;
 
-	for (int i = 0; i < reqbufs.count; i++)
+	for (unsigned int i = 0; i < reqbufs.count; i++)
 	{
 		v4l2_plane planes[VIDEO_MAX_PLANES];
 		v4l2_buffer buffer = {};

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -227,7 +227,7 @@ void H264Encoder::pollThread()
 {
 	while (true)
 	{
-		pollfd p = { fd_, POLLIN };
+		pollfd p = { fd_, POLLIN, 0 };
 		int ret = poll(&p, 1, 200);
 		if (abort_)
 			break;

--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -20,7 +20,8 @@ public:
 	H264Encoder(VideoOptions const *options);
 	~H264Encoder();
 	// Encode the given DMABUF.
-	void EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height, unsigned int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	// We want at least as many output buffers as there are in the camera queue

--- a/encoder/mjpeg_encoder.cpp
+++ b/encoder/mjpeg_encoder.cpp
@@ -38,7 +38,8 @@ MjpegEncoder::~MjpegEncoder()
 		std::cout << "MjpegEncoder closed" << std::endl;
 }
 
-void MjpegEncoder::EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us)
+void MjpegEncoder::EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height,
+								unsigned int stride, int64_t timestamp_us)
 {
 	std::lock_guard<std::mutex> lock(encode_mutex_);
 	EncodeItem item = { mem, width, height, stride, timestamp_us, index_++ };
@@ -74,7 +75,7 @@ void MjpegEncoder::encodeJPEG(struct jpeg_compress_struct &cinfo, EncodeItem &it
 	JSAMPROW u_rows[8];
 	JSAMPROW v_rows[8];
 
-	int height_align = item.height & ~15;
+	unsigned int height_align = item.height & ~15;
 	while (cinfo.next_scanline < height_align)
 	{
 		uint8_t *Y_row = Y + cinfo.next_scanline * item.stride;

--- a/encoder/mjpeg_encoder.cpp
+++ b/encoder/mjpeg_encoder.cpp
@@ -172,7 +172,7 @@ void MjpegEncoder::encodeThread(int num)
 void MjpegEncoder::outputThread()
 {
 	OutputItem item;
-	int index = 0;
+	uint64_t index = 0;
 	while (true)
 	{
 		{

--- a/encoder/mjpeg_encoder.hpp
+++ b/encoder/mjpeg_encoder.hpp
@@ -22,7 +22,8 @@ public:
 	MjpegEncoder(VideoOptions const *options);
 	~MjpegEncoder();
 	// Encode the given buffer.
-	void EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height, unsigned int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	// How many threads to use. Whichever thread is idle will pick up the next frame.
@@ -42,9 +43,9 @@ private:
 	struct EncodeItem
 	{
 		void *mem;
-		int width;
-		int height;
-		int stride;
+		unsigned int width;
+		unsigned int height;
+		unsigned int stride;
 		int64_t timestamp_us;
 		uint64_t index;
 	};

--- a/encoder/null_encoder.cpp
+++ b/encoder/null_encoder.cpp
@@ -27,7 +27,8 @@ NullEncoder::~NullEncoder()
 }
 
 // Push the buffer onto the output queue to be "encoded" and returned.
-void NullEncoder::EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us)
+void NullEncoder::EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height,
+							   unsigned int stride, int64_t timestamp_us)
 {
 	std::lock_guard<std::mutex> lock(output_mutex_);
 	OutputItem item = { mem, size, timestamp_us };

--- a/encoder/null_encoder.cpp
+++ b/encoder/null_encoder.cpp
@@ -11,7 +11,7 @@
 
 #include "null_encoder.hpp"
 
-NullEncoder::NullEncoder(VideoOptions const *options) : abort_(false), Encoder(options)
+NullEncoder::NullEncoder(VideoOptions const *options) : Encoder(options), abort_(false)
 {
 	if (options->verbose)
 		std::cout << "Opened NullEncoder" << std::endl;

--- a/encoder/null_encoder.hpp
+++ b/encoder/null_encoder.hpp
@@ -20,7 +20,8 @@ class NullEncoder : public Encoder
 public:
 	NullEncoder(VideoOptions const *options);
 	~NullEncoder();
-	void EncodeBuffer(int fd, size_t size, void *mem, int width, int height, int stride, int64_t timestamp_us) override;
+	void EncodeBuffer(int fd, size_t size, void *mem, unsigned int width, unsigned int height, unsigned int stride,
+					  int64_t timestamp_us) override;
 
 private:
 	void outputThread();

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -40,7 +40,7 @@ struct FileHeader
 };
 static_assert(sizeof(FileHeader) == 16, "FileHeader size wrong");
 
-void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options)
 {
 	if (pixel_format != libcamera::formats::RGB888)
@@ -70,7 +70,7 @@ void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, in
 			fwrite(&image_header, sizeof(image_header), 1, fp) != 1)
 			throw std::runtime_error("failed to write BMP file");
 
-		for (int i = 0; i < h; i++, ptr += stride)
+		for (unsigned int i = 0; i < h; i++, ptr += stride)
 		{
 			if (fwrite(ptr, line, 1, fp) != 1 || (pad != 0 && fwrite(padding, pad, 1, fp) != 1))
 				throw std::runtime_error("failed to write BMP file, row " + std::to_string(i));

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -41,14 +41,13 @@ static const std::map<PixelFormat, BayerFormat> bayer_formats =
 	{ formats::SGBRG12_CSI2P, { "GBRG-12", 12, TIFF_GBRG } },
 };
 
-static void unpack_10bit(uint8_t *src, int w, int h, int stride, uint16_t *dest)
+static void unpack_10bit(uint8_t *src, unsigned int w, unsigned int h, unsigned int stride, uint16_t *dest)
 {
-	int i = 0;
-	int w_align = w & ~3;
-	for (int y = 0; y < h; y++, src += stride)
+	unsigned int w_align = w & ~3;
+	for (unsigned int y = 0; y < h; y++, src += stride)
 	{
 		uint8_t *ptr = src;
-		int x;
+		unsigned int x;
 		for (x = 0; x < w_align; x += 4, ptr += 5)
 		{
 			*dest++ = (ptr[0] << 2) | ((ptr[4] >> 0) & 3);
@@ -61,14 +60,13 @@ static void unpack_10bit(uint8_t *src, int w, int h, int stride, uint16_t *dest)
 	}
 }
 
-static void unpack_12bit(uint8_t *src, int w, int h, int stride, uint16_t *dest)
+static void unpack_12bit(uint8_t *src, unsigned int w, unsigned int h, unsigned int stride, uint16_t *dest)
 {
-	int i = 0;
-	int w_align = w & ~1;
-	for (int y = 0; y < h; y++, src += stride)
+	unsigned int w_align = w & ~1;
+	for (unsigned int y = 0; y < h; y++, src += stride)
 	{
 		uint8_t *ptr = src;
-		int x;
+		unsigned int x;
 		for (x = 0; x < w_align; x += 2, ptr += 3)
 		{
 			*dest++ = (ptr[0] << 4) | ((ptr[2] >> 0) & 15);
@@ -128,7 +126,7 @@ Matrix(float m0, float m1, float m2,
 	}
 };
 
-void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  PixelFormat const &pixel_format, ControlList const &metadata, std::string const &filename,
 			  std::string const &cam_name, StillOptions const *options)
 {
@@ -258,11 +256,11 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, in
 		// Make a small greyscale thumbnail, just to give some clue what's in here.
 		std::vector<uint8_t> thumb_buf((w >> 4) * 3);
 
-		for (int y = 0; y < h >> 4; y++)
+		for (unsigned int y = 0; y < (h >> 4); y++)
 		{
-			for (int x = 0; x < w >> 4; x++)
+			for (unsigned int x = 0; x < (w >> 4); x++)
 			{
-				int off = (y * w + x) << 4;
+				unsigned int off = (y * w + x) << 4;
 				int grey = buf[off] + buf[off + 1] + buf[off + w] + buf[off + w + 1];
 				grey = white * sqrt(grey / (double)white); // fake "gamma"
 				thumb_buf[3 * x] = thumb_buf[3 * x + 1] = thumb_buf[3 * x + 2] = grey >> (bayer_format.bits - 6);
@@ -292,7 +290,7 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, in
 		TIFFSetField(tif, TIFFTAG_BLACKLEVELREPEATDIM, &black_level_repeat_dim);
 		TIFFSetField(tif, TIFFTAG_BLACKLEVEL, 4, &black_levels);
 
-		for (int y = 0; y < h; y++)
+		for (unsigned int y = 0; y < h; y++)
 		{
 			if (TIFFWriteScanline(tif, &buf[w * y], y, 0) != 1)
 				throw std::runtime_error("error writing DNG image data");

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -179,7 +179,7 @@ void exif_read_tag(ExifData *exif, char const *str)
 
 	char ifd_name[5];
 	char tag_name[128];
-	int bytes_consumed;
+	unsigned int bytes_consumed;
 	if (sscanf(str, "%4[^.].%127[^=]=%n", ifd_name, tag_name, &bytes_consumed) != 2)
 		throw std::runtime_error("failed to read EXIF IFD and tag");
 	if (exif_ifd_map.count(std::string(ifd_name)) == 0)
@@ -250,9 +250,9 @@ void exif_read_tag(ExifData *exif, char const *str)
 	}
 }
 
-static void YUYV_to_JPEG(const uint8_t *input, const int input_width, const int input_height, const int stride,
-						 const int output_width, const int output_height, const int quality, const unsigned int restart,
-						 uint8_t *&jpeg_buffer, jpeg_mem_len_t &jpeg_len)
+static void YUYV_to_JPEG(const uint8_t *input, const unsigned int input_width, const unsigned int input_height,
+						 const unsigned int stride, const unsigned int output_width, const unsigned int output_height,
+						 const int quality, const unsigned int restart, uint8_t *&jpeg_buffer, jpeg_mem_len_t &jpeg_len)
 {
 	struct jpeg_compress_struct cinfo;
 	struct jpeg_error_mgr jerr;
@@ -304,9 +304,9 @@ static void YUYV_to_JPEG(const uint8_t *input, const int input_width, const int 
 	jpeg_destroy_compress(&cinfo);
 }
 
-static void YUV420_to_JPEG_fast(const uint8_t *input, const int width, const int height, const int stride,
-								const int quality, const unsigned int restart, uint8_t *&jpeg_buffer,
-								jpeg_mem_len_t &jpeg_len)
+static void YUV420_to_JPEG_fast(const uint8_t *input, const unsigned int width, const unsigned int height,
+								const unsigned int stride, const int quality, const unsigned int restart,
+								uint8_t *&jpeg_buffer, jpeg_mem_len_t &jpeg_len)
 {
 	struct jpeg_compress_struct cinfo;
 	struct jpeg_error_mgr jerr;
@@ -337,7 +337,7 @@ static void YUV420_to_JPEG_fast(const uint8_t *input, const int width, const int
 	JSAMPROW u_rows[8];
 	JSAMPROW v_rows[8];
 
-	int height_align = height & ~15;
+	unsigned int height_align = height & ~15;
 	while (cinfo.next_scanline < height_align)
 	{
 		uint8_t *Y_row = Y + cinfo.next_scanline * stride;
@@ -375,9 +375,10 @@ static void YUV420_to_JPEG_fast(const uint8_t *input, const int width, const int
 	jpeg_destroy_compress(&cinfo);
 }
 
-static void YUV420_to_JPEG(const uint8_t *input, const int input_width, const int input_height, const int stride,
-						   const int output_width, const int output_height, const int quality,
-						   const unsigned int restart, uint8_t *&jpeg_buffer, jpeg_mem_len_t &jpeg_len)
+static void YUV420_to_JPEG(const uint8_t *input, const unsigned int input_width, const unsigned int input_height,
+						   const unsigned int stride, const unsigned int output_width, const unsigned int output_height,
+						   const int quality, const unsigned int restart, uint8_t *&jpeg_buffer,
+						   jpeg_mem_len_t &jpeg_len)
 {
 	if (input_width == output_width && input_height == output_height)
 	{
@@ -581,7 +582,7 @@ static void create_exif_data(PixelFormat const &pixel_format, std::vector<libcam
 	}
 }
 
-void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			   PixelFormat const &pixel_format, ControlList const &metadata, std::string const &filename,
 			   std::string const &cam_name, StillOptions const *options)
 {

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -179,7 +179,7 @@ void exif_read_tag(ExifData *exif, char const *str)
 
 	char ifd_name[5];
 	char tag_name[128];
-	unsigned int bytes_consumed;
+	int bytes_consumed;
 	if (sscanf(str, "%4[^.].%127[^=]=%n", ifd_name, tag_name, &bytes_consumed) != 2)
 		throw std::runtime_error("failed to read EXIF IFD and tag");
 	if (exif_ifd_map.count(std::string(ifd_name)) == 0)
@@ -242,7 +242,7 @@ void exif_read_tag(ExifData *exif, char const *str)
 	size_t len = strlen(str);
 	for (unsigned i = 0; i < entry->components; i++)
 	{
-		if (bytes_consumed >= len)
+		if (static_cast<unsigned int>(bytes_consumed) >= len)
 			throw std::runtime_error("too few parameters for EXIF tag " + tag_string);
 		unsigned char *dest = entry->data + i * item_size;
 		int extra_consumed = (exif_read_functions[entry->format])(str + bytes_consumed, dest);

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -15,7 +15,7 @@
 
 #include "core/still_options.hpp"
 
-void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options)
 {
 	if (pixel_format != libcamera::formats::BGR888)
@@ -52,7 +52,7 @@ void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, in
 		// Set up the image data.
 		png_byte **row_ptrs = (png_byte **)png_malloc(png_ptr, h * sizeof(png_byte *));
 		png_byte *row = (uint8_t *)mem[0].data();
-		for (int i = 0; i < h; i++, row += stride)
+		for (unsigned int i = 0; i < h; i++, row += stride)
 			row_ptrs[i] = row;
 
 		png_init_io(png_ptr, fp);

--- a/image/yuv.cpp
+++ b/image/yuv.cpp
@@ -10,8 +10,8 @@
 
 #include "core/still_options.hpp"
 
-static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
-						std::string const &filename, StillOptions const *options)
+static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h,
+						unsigned int stride, std::string const &filename, StillOptions const *options)
 {
 	if (options->encoding == "yuv420")
 	{
@@ -25,20 +25,20 @@ static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w,
 		try
 		{
 			uint8_t *Y = (uint8_t *)mem[0].data();
-			for (int j = 0; j < h; j++)
+			for (unsigned int j = 0; j < h; j++)
 			{
 				if (fwrite(Y + j * stride, w, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
 			uint8_t *U = Y + stride * h;
 			h /= 2, w /= 2, stride /= 2;
-			for (int j = 0; j < h; j++)
+			for (unsigned int j = 0; j < h; j++)
 			{
 				if (fwrite(U + j * stride, w, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
 			uint8_t *V = U + stride * h;
-			for (int j = 0; j < h; j++)
+			for (unsigned int j = 0; j < h; j++)
 			{
 				if (fwrite(V + j * stride, w, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
@@ -54,8 +54,8 @@ static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w,
 		throw std::runtime_error("output format " + options->encoding + " not supported");
 }
 
-static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
-					  std::string const &filename, StillOptions const *options)
+static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h,
+					  unsigned int stride, std::string const &filename, StillOptions const *options)
 {
 	if (options->encoding == "yuv420")
 	{
@@ -70,25 +70,25 @@ static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, i
 			// YUV420 planar buffer would have been nice.
 			std::vector<uint8_t> row(w);
 			uint8_t *ptr = (uint8_t *)mem[0].data();
-			for (int j = 0; j < h; j++, ptr += stride)
+			for (unsigned int j = 0; j < h; j++, ptr += stride)
 			{
-				for (int i = 0; i < w; i++)
+				for (unsigned int i = 0; i < w; i++)
 					row[i] = ptr[i << 1];
 				if (fwrite(&row[0], w, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
 			ptr = (uint8_t *)mem[0].data();
-			for (int j = 0; j < h; j += 2, ptr += 2 * stride)
+			for (unsigned int j = 0; j < h; j += 2, ptr += 2 * stride)
 			{
-				for (int i = 0; i < w / 2; i++)
+				for (unsigned int i = 0; i < w / 2; i++)
 					row[i] = ptr[(i << 2) + 1];
 				if (fwrite(&row[0], w / 2, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
 			ptr = (uint8_t *)mem[0].data();
-			for (int j = 0; j < h; j += 2, ptr += 2 * stride)
+			for (unsigned int j = 0; j < h; j += 2, ptr += 2 * stride)
 			{
-				for (int i = 0; i < w / 2; i++)
+				for (unsigned int i = 0; i < w / 2; i++)
 					row[i] = ptr[(i << 2) + 3];
 				if (fwrite(&row[0], w / 2, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
@@ -105,8 +105,8 @@ static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, i
 		throw std::runtime_error("output format " + options->encoding + " not supported");
 }
 
-static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
-					 std::string const &filename, StillOptions const *options)
+static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h,
+					 unsigned int stride, std::string const &filename, StillOptions const *options)
 {
 	if (options->encoding != "rgb")
 		throw std::runtime_error("encoding should be set to rgb");
@@ -116,7 +116,7 @@ static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, in
 	try
 	{
 		uint8_t *ptr = (uint8_t *)mem[0].data();
-		for (int j = 0; j < h; j++, ptr += stride)
+		for (unsigned int j = 0; j < h; j++, ptr += stride)
 		{
 			if (fwrite(ptr, 3 * w, 1, fp) != 1)
 				throw std::runtime_error("failed to write file " + filename);
@@ -130,7 +130,7 @@ static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, in
 	}
 }
 
-void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, int w, int h, int stride,
+void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, unsigned int w, unsigned int h, unsigned int stride,
 			  libcamera::PixelFormat const &pixel_format, std::string const &filename, StillOptions const *options)
 {
 	if (pixel_format == libcamera::formats::YUYV)

--- a/output/circular_output.cpp
+++ b/output/circular_output.cpp
@@ -20,7 +20,7 @@ struct Header
 };
 static_assert(sizeof(Header) % ALIGN == 0, "Header should have aligned size");
 
-CircularOutput::CircularOutput(VideoOptions const *options) : cb_(CIRCULAR_BUFFER_SIZE), Output(options)
+CircularOutput::CircularOutput(VideoOptions const *options) : Output(options), cb_(CIRCULAR_BUFFER_SIZE)
 {
 	// Open this now, so that we can get any complaints out of the way
 	fp_ = fopen(options_->output.c_str(), "w");

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -54,7 +54,7 @@ void FileOutput::openFile(int64_t timestamp_us)
 		count_++;
 		if (options_->wrap)
 			count_ = count_ % options_->wrap;
-		if (n < 0 || n >= sizeof(filename))
+		if (n < 0)
 			throw std::runtime_error("failed to generate filename");
 
 		fp_ = fopen(filename, "w");

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -8,7 +8,7 @@
 #include "file_output.hpp"
 
 FileOutput::FileOutput(VideoOptions const *options)
-	: fp_(nullptr), count_(0), file_start_time_ms_(0), Output(options)
+	: Output(options), fp_(nullptr), count_(0), file_start_time_ms_(0)
 {
 }
 

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -14,7 +14,7 @@
 #include "output.hpp"
 
 Output::Output(VideoOptions const *options)
-	: state_(WAITING_KEYFRAME), options_(options), fp_timestamps_(nullptr), time_offset_(0), last_timestamp_(0)
+	: options_(options), state_(WAITING_KEYFRAME), fp_timestamps_(nullptr), time_offset_(0), last_timestamp_(0)
 {
 	if (!options->save_pts.empty())
 	{

--- a/post_processing_stages/annotate_cv_stage.cpp
+++ b/post_processing_stages/annotate_cv_stage.cpp
@@ -29,9 +29,9 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	Stream *stream_;

--- a/post_processing_stages/annotate_cv_stage.cpp
+++ b/post_processing_stages/annotate_cv_stage.cpp
@@ -35,7 +35,7 @@ public:
 
 private:
 	Stream *stream_;
-	int width_, height_, stride_;
+	unsigned int width_, height_, stride_;
 	std::string text_;
 	int fg_;
 	int bg_;
@@ -74,7 +74,7 @@ void AnnotateCvStage::Configure()
 	// size is preserved across different camera modes. Note that the thickness can get
 	// rather harshly quantised, not much we can do about that.
 	adjusted_scale_ = scale_ * width_ / 1200;
-	adjusted_thickness_ = std::max(thickness_ * width_ / 700, 1);
+	adjusted_thickness_ = std::max(thickness_ * width_ / 700, 1u);
 }
 
 bool AnnotateCvStage::Process(CompletedRequest &completed_request)

--- a/post_processing_stages/face_detect_cv_stage.cpp
+++ b/post_processing_stages/face_detect_cv_stage.cpp
@@ -123,7 +123,7 @@ bool FaceDetectCvStage::Process(CompletedRequest &completed_request)
 			image_ = image.clone();
 
 			future_ptr_ = std::make_unique<std::future<void>>();
-			*future_ptr_ = std::move(std::async(std::launch::async, [this] { detectFeatures(cascade_); }));
+			*future_ptr_ = std::async(std::launch::async, [this] { detectFeatures(cascade_); });
 		}
 	}
 

--- a/post_processing_stages/face_detect_cv_stage.cpp
+++ b/post_processing_stages/face_detect_cv_stage.cpp
@@ -43,9 +43,9 @@ private:
 	void drawFeatures(cv::Mat &img);
 
 	Stream *stream_;
-	int width_, height_, stride_;
+	unsigned int width_, height_, stride_;
 	Stream *full_stream_;
-	int full_width_, full_height_, full_stride_;
+	unsigned int full_width_, full_height_, full_stride_;
 	std::unique_ptr<std::future<void>> future_ptr_;
 	std::mutex face_mutex_;
 	std::mutex future_ptr_mutex_;

--- a/post_processing_stages/face_detect_cv_stage.cpp
+++ b/post_processing_stages/face_detect_cv_stage.cpp
@@ -32,11 +32,11 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
-	void Stop();
+	void Stop() override;
 
 private:
 	void detectFeatures(cv::CascadeClassifier &cascade);

--- a/post_processing_stages/hdr_stage.cpp
+++ b/post_processing_stages/hdr_stage.cpp
@@ -380,13 +380,13 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	Stream *stream_;
-	int width_, height_, stride_;
+	unsigned width_, height_, stride_;
 	HdrConfig config_;
 	unsigned int frame_num_;
 	std::mutex mutex_;

--- a/post_processing_stages/hdr_stage.cpp
+++ b/post_processing_stages/hdr_stage.cpp
@@ -154,20 +154,20 @@ static void forward_pass(std::vector<double> &fwd_pixels, std::vector<double> &f
 			double pixel_wt_sum = pixel * strength, wt_sum = strength;
 
 			// Compiler generates faster code from this:
-			int p[4], idx[4];
+			unsigned int p[4], idx[4];
 			double wt[4];
 			p[0] = fwd_pixels[off - width - 1];
 			p[1] = fwd_pixels[off - width];
 			p[2] = fwd_pixels[off - width + 1];
 			p[3] = fwd_pixels[off - 1];
-			idx[0] = abs(p[0] - pixel) * scale;
-			idx[1] = abs(p[1] - pixel) * scale;
-			idx[2] = abs(p[2] - pixel) * scale;
-			idx[3] = abs(p[3] - pixel) * scale;
-			wt[0] = idx[0] >= weights.size() ? 0 : weights[idx[0]];
-			wt[1] = idx[1] >= weights.size() ? 0 : weights[idx[1]];
-			wt[2] = idx[2] >= weights.size() ? 0 : weights[idx[2]];
-			wt[3] = idx[3] >= weights.size() ? 0 : weights[idx[3]];
+			idx[0] = std::abs(static_cast<int>(p[0]) - pixel) * scale;
+			idx[1] = std::abs(static_cast<int>(p[1]) - pixel) * scale;
+			idx[2] = std::abs(static_cast<int>(p[2]) - pixel) * scale;
+			idx[3] = std::abs(static_cast<int>(p[3]) - pixel) * scale;
+			wt[0] = idx[0] >= weights.size() ? 0.0 : weights[idx[0]];
+			wt[1] = idx[1] >= weights.size() ? 0.0 : weights[idx[1]];
+			wt[2] = idx[2] >= weights.size() ? 0.0 : weights[idx[2]];
+			wt[3] = idx[3] >= weights.size() ? 0.0 : weights[idx[3]];
 			pixel_wt_sum += wt[0] * p[0] + wt[1] * p[1] + wt[2] * p[2] + wt[3] * p[3];
 			wt_sum += wt[0] + wt[1] + wt[2] + wt[3];
 
@@ -221,20 +221,20 @@ HdrImage HdrImage::LpFilter(LpFilterConfig const &config) const
 			double pixel_wt_sum = pixel * strength, wt_sum = strength;
 
 			// Compiler generates faster code from this:
-			int p[4], idx[4];
+			unsigned int p[4], idx[4];
 			double wt[4];
 			p[0] = rev_pixels[off + width + 1];
 			p[1] = rev_pixels[off + width];
 			p[2] = rev_pixels[off + width - 1];
 			p[3] = rev_pixels[off + 1];
-			idx[0] = abs(p[0] - pixel) * scale;
-			idx[1] = abs(p[1] - pixel) * scale;
-			idx[2] = abs(p[2] - pixel) * scale;
-			idx[3] = abs(p[3] - pixel) * scale;
-			wt[0] = idx[0] >= weights.size() ? 0 : weights[idx[0]];
-			wt[1] = idx[1] >= weights.size() ? 0 : weights[idx[1]];
-			wt[2] = idx[2] >= weights.size() ? 0 : weights[idx[2]];
-			wt[3] = idx[3] >= weights.size() ? 0 : weights[idx[3]];
+			idx[0] = std::abs(static_cast<int>(p[0]) - pixel) * scale;
+			idx[1] = std::abs(static_cast<int>(p[1]) - pixel) * scale;
+			idx[2] = std::abs(static_cast<int>(p[2]) - pixel) * scale;
+			idx[3] = std::abs(static_cast<int>(p[3]) - pixel) * scale;
+			wt[0] = idx[0] >= weights.size() ? 0.0 : weights[idx[0]];
+			wt[1] = idx[1] >= weights.size() ? 0.0 : weights[idx[1]];
+			wt[2] = idx[2] >= weights.size() ? 0.0 : weights[idx[2]];
+			wt[3] = idx[3] >= weights.size() ? 0.0 : weights[idx[3]];
 			pixel_wt_sum += wt[0] * p[0] + wt[1] * p[1] + wt[2] * p[2] + wt[3] * p[3];
 			wt_sum += wt[0] + wt[1] + wt[2] + wt[3];
 

--- a/post_processing_stages/motion_detect_stage.cpp
+++ b/post_processing_stages/motion_detect_stage.cpp
@@ -54,12 +54,12 @@ private:
 		bool verbose;
 	} config_;
 	Stream *stream_;
-	int lores_stride_;
+	unsigned lores_stride_;
 	// Here we convert the dimensions to pixel locations in the lores image, as if subsampled
 	// by hskip and vskip.
-	int roi_x_, roi_y_;
-	int roi_width_, roi_height_;
-	int region_threshold_;
+	unsigned int roi_x_, roi_y_;
+	unsigned int roi_width_, roi_height_;
+	unsigned int region_threshold_;
 	std::vector<uint8_t> previous_frame_;
 	bool first_time_;
 	bool motion_detected_;
@@ -90,7 +90,7 @@ void MotionDetectStage::Read(boost::property_tree::ptree const &params)
 
 void MotionDetectStage::Configure()
 {
-	int lores_width, lores_height;
+	unsigned lores_width, lores_height;
 	stream_ = app_->LoresStream(&lores_width, &lores_height, &lores_stride_);
 	if (!stream_)
 		return;
@@ -109,11 +109,11 @@ void MotionDetectStage::Configure()
 	roi_height_ = config_.roi_height * lores_height;
 	region_threshold_ = config_.region_threshold * roi_width_ * roi_height_;
 
-	roi_x_ = std::clamp(roi_x_, 0, lores_width);
-	roi_y_ = std::clamp(roi_y_, 0, lores_height);
-	roi_width_ = std::clamp(roi_width_, 0, lores_width - roi_x_);
-	roi_height_ = std::clamp(roi_height_, 0, lores_height - roi_y_);
-	region_threshold_ = std::clamp(region_threshold_, 0, roi_width_ * roi_height_);
+	roi_x_ = std::clamp(roi_x_, 0u, lores_width);
+	roi_y_ = std::clamp(roi_y_, 0u, lores_height);
+	roi_width_ = std::clamp(roi_width_, 0u, lores_width - roi_x_);
+	roi_height_ = std::clamp(roi_height_, 0u, lores_height - roi_y_);
+	region_threshold_ = std::clamp(region_threshold_, 0u, roi_width_ * roi_height_);
 
 	if (config_.verbose)
 		std::cout << "Lores: " << lores_width << "x" << lores_height << " roi: (" << roi_x_ << "," << roi_y_ << ") "
@@ -141,11 +141,11 @@ bool MotionDetectStage::Process(CompletedRequest &completed_request)
 	if (first_time_)
 	{
 		first_time_ = false;
-		for (int y = 0; y < roi_height_; y++)
+		for (unsigned int y = 0; y < roi_height_; y++)
 		{
 			uint8_t *new_value_ptr = image + (roi_y_ + y) * lores_stride_ + roi_x_ * config_.hskip;
 			uint8_t *old_value_ptr = &previous_frame_[0] + y * roi_width_;
-			for (int x = 0; x < roi_width_; x++, new_value_ptr += config_.hskip)
+			for (unsigned int x = 0; x < roi_width_; x++, new_value_ptr += config_.hskip)
 				*(old_value_ptr++) = *new_value_ptr;
 		}
 
@@ -155,15 +155,15 @@ bool MotionDetectStage::Process(CompletedRequest &completed_request)
 	}
 
 	bool motion_detected = false;
-	int regions = 0;
+	unsigned int regions = 0;
 
 	// Count the lores pixels where the difference between the new and previous values
 	// exceeds the threshold. At the same time, update the previous image buffer.
-	for (int y = 0; y < roi_height_; y++)
+	for (unsigned int y = 0; y < roi_height_; y++)
 	{
 		uint8_t *new_value_ptr = image + (roi_y_ + y) * lores_stride_ + roi_x_ * config_.hskip;
 		uint8_t *old_value_ptr = &previous_frame_[0] + y * roi_width_;
-		for (int x = 0; x < roi_width_; x++, new_value_ptr += config_.hskip)
+		for (unsigned int x = 0; x < roi_width_; x++, new_value_ptr += config_.hskip)
 		{
 			int new_value = *new_value_ptr;
 			int old_value = *old_value_ptr;

--- a/post_processing_stages/motion_detect_stage.cpp
+++ b/post_processing_stages/motion_detect_stage.cpp
@@ -36,9 +36,9 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	// In the Config, dimensions are given as fractions of the lores image size.

--- a/post_processing_stages/negate_stage.cpp
+++ b/post_processing_stages/negate_stage.cpp
@@ -21,9 +21,9 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override {}
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	Stream *stream_;

--- a/post_processing_stages/object_classify_tf_stage.cpp
+++ b/post_processing_stages/object_classify_tf_stage.cpp
@@ -65,7 +65,7 @@ void ObjectClassifyTfStage::readExtras(boost::property_tree::ptree const &params
 	int output = interpreter_->outputs()[0];
 	TfLiteIntArray *output_dims = interpreter_->tensor(output)->dims;
 	// Causes might include loading the wrong model, or the wrong labels file.
-	if (output_dims->data[output_dims->size - 1] != label_count_)
+	if (output_dims->data[output_dims->size - 1] != static_cast<int>(label_count_))
 		throw std::runtime_error("ObjectClassifyTfStage: Label count mismatch");
 }
 

--- a/post_processing_stages/object_detect_draw_cv_stage.cpp
+++ b/post_processing_stages/object_detect_draw_cv_stage.cpp
@@ -60,7 +60,7 @@ bool ObjectDetectDrawCvStage::Process(CompletedRequest &completed_request)
 	if (!stream_)
 		return false;
 
-	int w, h, stride;
+	unsigned int w, h, stride;
 	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
 	uint32_t *ptr = (uint32_t *)buffer.data();
 	app_->StreamDimensions(stream_, &w, &h, &stride);

--- a/post_processing_stages/object_detect_draw_cv_stage.cpp
+++ b/post_processing_stages/object_detect_draw_cv_stage.cpp
@@ -24,11 +24,11 @@ public:
 
 	char const *Name() const override;
 
-	void Read(boost::property_tree::ptree const &params);
+	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	Stream *stream_;

--- a/post_processing_stages/plot_pose_cv_stage.cpp
+++ b/post_processing_stages/plot_pose_cv_stage.cpp
@@ -54,11 +54,11 @@ public:
 
 	char const *Name() const override;
 
-	void Read(boost::property_tree::ptree const &params);
+	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	void drawFeatures(cv::Mat &img, std::vector<Point> locations, std::vector<float> confidences);

--- a/post_processing_stages/plot_pose_cv_stage.cpp
+++ b/post_processing_stages/plot_pose_cv_stage.cpp
@@ -89,7 +89,7 @@ bool PlotPoseCvStage::Process(CompletedRequest &completed_request)
 	if (!stream_)
 		return false;
 
-	int w, h, stride;
+	unsigned int w, h, stride;
 	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
 	uint32_t *ptr = (uint32_t *)buffer.data();
 	app_->StreamDimensions(stream_, &w, &h, &stride);

--- a/post_processing_stages/segmentation_tf_stage.cpp
+++ b/post_processing_stages/segmentation_tf_stage.cpp
@@ -70,7 +70,8 @@ void SegmentationTfStage::readExtras([[maybe_unused]] boost::property_tree::ptre
 	// Check the output dimensions.
 	int output = interpreter_->outputs()[0];
 	TfLiteIntArray *dims = interpreter_->tensor(output)->dims;
-	if (dims->size != 4 || dims->data[1] != HEIGHT || dims->data[2] != WIDTH || dims->data[3] != labels_.size())
+	if (dims->size != 4 || dims->data[1] != HEIGHT || dims->data[2] != WIDTH ||
+		dims->data[3] != static_cast<int>(labels_.size()))
 		throw std::runtime_error("SegmentationTfStage: Unexpected output tensor size");
 }
 

--- a/post_processing_stages/sobel_cv_stage.cpp
+++ b/post_processing_stages/sobel_cv_stage.cpp
@@ -25,9 +25,9 @@ public:
 
 	void Read(boost::property_tree::ptree const &params) override;
 
-	void Configure();
+	void Configure() override;
 
-	bool Process(CompletedRequest &completed_request);
+	bool Process(CompletedRequest &completed_request) override;
 
 private:
 	Stream *stream_;

--- a/post_processing_stages/sobel_cv_stage.cpp
+++ b/post_processing_stages/sobel_cv_stage.cpp
@@ -55,7 +55,7 @@ void SobelCvStage::Configure()
 
 bool SobelCvStage::Process(CompletedRequest &completed_request)
 {
-	int w, h, stride;
+	unsigned int w, h, stride;
 	app_->StreamDimensions(stream_, &w, &h, &stride);
 	libcamera::Span<uint8_t> buffer = app_->Mmap(completed_request.buffers[stream_])[0];
 	uint8_t *ptr = (uint8_t *)buffer.data();

--- a/post_processing_stages/tf_stage.cpp
+++ b/post_processing_stages/tf_stage.cpp
@@ -111,12 +111,12 @@ bool TfStage::Process(CompletedRequest &completed_request)
 			lores_copy_.assign(buffer.data(), buffer.data() + buffer.size());
 
 			future_ = std::make_unique<std::future<void>>();
-			*future_ = std::move(std::async(std::launch::async, [this] {
+			*future_ = std::async(std::launch::async, [this] {
 				auto time_taken = ExecutionTime<std::micro>(&TfStage::runInference, this).count();
 
 				if (config_->verbose)
 					std::cout << "TfStage: Inference time: " << time_taken << " ms" << std::endl;
-			}));
+			});
 		}
 	}
 

--- a/post_processing_stages/tf_stage.cpp
+++ b/post_processing_stages/tf_stage.cpp
@@ -135,13 +135,13 @@ void TfStage::runInference()
 	if (interpreter_->tensor(input)->type == kTfLiteUInt8)
 	{
 		uint8_t *tensor = interpreter_->typed_tensor<uint8_t>(input);
-		for (int i = 0; i < rgb_image.size(); i++)
+		for (unsigned int i = 0; i < rgb_image.size(); i++)
 			tensor[i] = rgb_image[i];
 	}
 	else if (interpreter_->tensor(input)->type == kTfLiteFloat32)
 	{
 		float *tensor = interpreter_->typed_tensor<float>(input);
-		for (int i = 0; i < rgb_image.size(); i++)
+		for (unsigned int i = 0; i < rgb_image.size(); i++)
 			tensor[i] = (rgb_image[i] - config_->normalisation_offset) / config_->normalisation_scale;
 	}
 

--- a/post_processing_stages/tf_stage.hpp
+++ b/post_processing_stages/tf_stage.hpp
@@ -80,15 +80,15 @@ protected:
 	std::unique_ptr<TfConfig> config_;
 
 	// The width and height that TFLite wants.
-	int tf_w_, tf_h_;
+	unsigned int tf_w_, tf_h_;
 
 	// We run TFLite on the low resolution image, details of which are here.
 	libcamera::Stream *lores_stream_;
-	int lores_w_, lores_h_, lores_stride_;
+	unsigned int lores_w_, lores_h_, lores_stride_;
 
 	// The stage may or may not make use of the larger or "main" image stream.
 	libcamera::Stream *main_stream_;
-	int main_w_, main_h_, main_stride_;
+	unsigned int main_w_, main_h_, main_stride_;
 
 	std::unique_ptr<tflite::FlatBufferModel> model_;
 	std::unique_ptr<tflite::Interpreter> interpreter_;

--- a/preview/CMakeLists.txt
+++ b/preview/CMakeLists.txt
@@ -39,6 +39,11 @@ if (QTCORE_FOUND AND QTWIDGETS_FOUND)
     message(STATUS "QTCORE_INCLUDE_DIRS=${QTCORE_INCLUDE_DIRS}")
     include_directories(${QTCORE_INCLUDE_DIRS} ${QTWIDGETS_INCLUDE_DIRS})
     set(TARGET_LIBS ${TARGET_LIBS} ${QTCORE_LIBRARIES} ${QTWIDGETS_LIBRARIES})
+    # The qt5/QtCore/qvariant.h header throws a warning, so suppress this.
+    # Annoyingly there are two different (incompatible) flags for clang < 10
+    # and >= 10, so set both, and supress unknown options warnings.
+    set_source_files_properties(qt_preview.cpp PROPERTIES COMPILE_FLAGS
+                                "-Wno-unknown-warning-option -Wno-deprecated-copy -Wno-deprecated")
     set(SRC ${SRC} qt_preview.cpp)
     set(QT_FOUND 1)
 else()

--- a/preview/drm_preview.cpp
+++ b/preview/drm_preview.cpp
@@ -225,7 +225,7 @@ void DrmPreview::findPlane()
 	drmModeFreePlaneResources(planes);
 }
 
-DrmPreview::DrmPreview(Options const *options) : last_fd_(-1), Preview(options)
+DrmPreview::DrmPreview(Options const *options) : Preview(options), last_fd_(-1)
 {
 	drmfd_ = drmOpen("vc4", NULL);
 	if (drmfd_ < 0)

--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -239,7 +239,6 @@ void EglPreview::makeWindow(char const *name)
 	XSetWindowAttributes attr;
 	unsigned long mask;
 	Window root = RootWindow(display_, screen_num);
-	Window win;
 	int screen_width = DisplayWidth(display_, screen_num);
 	int screen_height = DisplayHeight(display_, screen_num);
 
@@ -400,7 +399,7 @@ void EglPreview::Show(int fd, libcamera::Span<uint8_t> span, int width, int heig
 
 	glBindTexture(GL_TEXTURE_EXTERNAL_OES, buffer.texture);
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-	EGLBoolean success = eglSwapBuffers(egl_display_, egl_surface_);
+	EGLBoolean success [[maybe_unused]] = eglSwapBuffers(egl_display_, egl_surface_);
 	if (last_fd_ >= 0)
 		done_callback_(last_fd_);
 	last_fd_ = fd;

--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -163,7 +163,7 @@ static void gl_setup(int width, int height, int window_width, int window_height)
 	glEnableVertexAttribArray(0);
 }
 
-EglPreview::EglPreview(Options const *options) : last_fd_(-1), first_time_(true), Preview(options)
+EglPreview::EglPreview(Options const *options) : Preview(options), last_fd_(-1), first_time_(true)
 {
 	display_ = XOpenDisplay(NULL);
 	if (!display_)

--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -418,7 +418,7 @@ bool EglPreview::Quit()
 	XEvent event;
 	while (XCheckTypedWindowEvent(display_, window_, ClientMessage, &event))
 	{
-		if (event.xclient.data.l[0] == wm_delete_window_)
+		if (static_cast<Atom>(event.xclient.data.l[0]) == wm_delete_window_)
 			return true;
 	}
 	return false;

--- a/preview/preview.hpp
+++ b/preview/preview.hpp
@@ -12,7 +12,7 @@
 
 #include <libcamera/base/span.h>
 
-class Options;
+struct Options;
 
 class Preview
 {


### PR DESCRIPTION
@davidplowman here are a bunch of changes that should get rid of all compiler warnings for both clang and gcc.