### PR TITLE
test: Add post-processing tests

### DIFF
--- a/.github/workflows/libcamera-apps-test.yml
+++ b/.github/workflows/libcamera-apps-test.yml
@@ -92,7 +92,7 @@ jobs:
       run: tar -xvf build-artifacts-gcc.tar --one-top-level=build
 
     - name: Test
-      run: ${{github.workspace}}/test.py --exe-dir ${{github.workspace}}/build --output-dir ${{github.workspace}}/test_output
+      run: ${{github.workspace}}/test.py --exe-dir ${{github.workspace}}/build --output-dir ${{github.workspace}}/test_output --json-dir ${{github.workspace}}/assets
       timeout-minutes: 5
 
     - name: Upload test output
@@ -126,7 +126,7 @@ jobs:
       run: tar -xvf build-artifacts-gcc.tar --one-top-level=build
 
     - name: Test
-      run: ${{github.workspace}}/test.py --exe-dir ${{github.workspace}}/build --output-dir ${{github.workspace}}/test_output
+      run: ${{github.workspace}}/test.py --exe-dir ${{github.workspace}}/build --output-dir ${{github.workspace}}/test_output --json-dir ${{github.workspace}}/assets
       timeout-minutes: 5
 
     - name: Upload test output


### PR DESCRIPTION
Runs a small selection of post-processing tests. Warnings are printed
if OpenCV, TFLite or the model used by TFLite are not found, but the
tests are not marked as failures.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>