### PR TITLE
core: Initialise control list correctly as "controls::controls"

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -12,7 +12,8 @@
 #include "core/options.hpp"
 
 LibcameraApp::LibcameraApp(std::unique_ptr<Options> opts)
-	: options_(std::move(opts)), preview_thread_(&LibcameraApp::previewThread, this), post_processor_(this)
+	: options_(std::move(opts)), preview_thread_(&LibcameraApp::previewThread, this), controls_(controls::controls),
+	  post_processor_(this)
 {
 	if (!options_)
 		options_ = std::make_unique<Options>();


### PR DESCRIPTION
This is necessary to stop the IPA process from aborting if it is
running in "isolation" mode.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>