### PR TITLE
tests: Do not wildcard *.txt files in clean_dir()

### DIFF
--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ def check_exists(file, preamble):
     if not os.path.isfile(file):
         raise TestFailure(preamble + ": " + file + " not found")
 
-def clean_dir(dir, exts = ('.jpg', '.png', '.bmp', '.dng', '.h264', '.mjpeg', '.raw', '.txt')):
+def clean_dir(dir, exts = ('.jpg', '.png', '.bmp', '.dng', '.h264', '.mjpeg', '.raw', 'log.txt')):
     for file in os.listdir(dir):
         if file.endswith(exts):
             os.remove(os.path.join(dir, file))


### PR DESCRIPTION
If the output directory is unspecified, it gets set to ./ which is the top level
of the git tree, and the clean_dir() will go ahead and remove CMakelists.txt
and license.txt.

Instead of the wildcard, use log.txt explicitly.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>