### PR TITLE
build: Add cpack support for src/bin distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,15 @@ elseif ("${ENABLE_COMPILE_FLAGS_FOR_TARGET}" STREQUAL "armv8-neon")
     add_definitions(-mfpu=neon-fp-armv8 -ftree-vectorize)
 endif()
 
+# Source package generation setup.
+set(CPACK_GENERATOR "TXZ")
+set(CPACK_PACKAGE_FILE_NAME "libcamera-apps-build")
+set(CPACK_SOURCE_GENERATOR "TXZ")
+set(CPACK_INSTALL_SCRIPTS ${CMAKE_SOURCE_DIR}/package.cmake)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "libcamera-apps-src")
+set(CPACK_SOURCE_IGNORE_FILES "/\.git*;/build;")
+include(CPack)
+
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(LIBCAMERA REQUIRED libcamera)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,7 +4,7 @@ include(GNUInstallDirs)
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 
-add_custom_target(VersionCpp ${CMAKE_COMMAND} -DVERSION_SHA=${VERSION_SHA} -P ${CMAKE_CURRENT_LIST_DIR}/version.cmake)
+add_custom_target(VersionCpp ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_SOURCE_DIR} -P ${CMAKE_CURRENT_LIST_DIR}/version.cmake)
 set_source_files_properties(version.cpp PROPERTIES GENERATED 1)
 
 add_library(libcamera_app libcamera_app.cpp post_processor.cpp version.cpp)

--- a/core/version.cmake
+++ b/core/version.cmake
@@ -1,9 +1,13 @@
 # Script to generate a version string and embed it in the version.cpp source file
 
-if (NOT VERSION_SHA STREQUAL "")
-    message("Using user supplied version sha: " ${VERSION_SHA})
+if (EXISTS ${SOURCE_DIR}/version.gen)
+    message("Reading version string from version.gen")
+    file(READ ${SOURCE_DIR}/version.gen SHA)
 endif()
 
-execute_process(COMMAND ${CMAKE_CURRENT_LIST_DIR}/version.py ${VERSION_SHA} OUTPUT_VARIABLE VER)
-message("Generating version string: " ${VER})
+execute_process(COMMAND ${SOURCE_DIR}/core/version.py ${SHA}
+                WORKING_DIRECTORY ${SOURCE_DIR}
+                OUTPUT_VARIABLE VER)
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/version.cpp.in version.cpp @ONLY)
+message("Generating version string: " ${VER})

--- a/package.cmake
+++ b/package.cmake
@@ -1,0 +1,5 @@
+# Script to generate a version string and save it to the package source root
+
+execute_process(COMMAND git rev-parse HEAD
+                WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                OUTPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/version.gen)


### PR DESCRIPTION
The new make target "package_source" will now save the upstream git commit SHA
into a file that is saved in the source tarball generated.  This SHA will then
be used by the version.py script when building from the tarball, and preserving
the upstream SHA versioning.

This removes the usage of the -DVERSION_SHA=... command line argument.

As a drive-by change, rename the -auto flag to -intree.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>