### PR TITLE
libcamera-still: In keypress/signal mode return to preview after capture

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -237,7 +237,7 @@ static void event_loop(LibcameraStillApp &app)
 			app.StopCamera();
 			std::cerr << "Still capture image received" << std::endl;
 			save_images(app, std::get<CompletedRequestPtr>(msg.payload));
-			if (options->timelapse)
+			if (options->timelapse || options->signal || options->keypress)
 			{
 				app.Teardown();
 				app.ConfigureViewfinder();


### PR DESCRIPTION
The intended behaviour is that you can do one capture after
another. The mechanism for quitting is unchanged (x+Enter or USR2).

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>