### PR TITLE
libcamera-still: Fix signal mode bug where images got captured repeat…

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -134,6 +134,7 @@ static int get_key_or_signal(StillOptions const *options, pollfd p[1])
 			key = '\n';
 		else if (signal_received == SIGUSR2)
 			key = 'x';
+		signal_received = 0;
 	}
 	return key;
 }


### PR DESCRIPTION
…edly

The "signal received" indicator was never being cleared.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>