### PR TITLE
libcamera-vid: Add a new --frames option to run for a set number of f…

### DIFF
--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -82,8 +82,10 @@ static void event_loop(LibcameraEncoder &app)
 		if (options->verbose)
 			std::cerr << "Viewfinder frame " << count << std::endl;
 		auto now = std::chrono::high_resolution_clock::now();
-		if ((options->timeout && now - start_time > std::chrono::milliseconds(options->timeout)) || key == 'x' ||
-			key == 'X')
+		bool timeout = !options->frames && options->timeout &&
+					   (now - start_time > std::chrono::milliseconds(options->timeout));
+		bool frameout = options->frames && count >= options->frames;
+		if (timeout || frameout || key == 'x' || key == 'X')
 		{
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -51,6 +51,8 @@ struct VideoOptions : public Options
 			 "Break the recording into files of approximately this many milliseconds")
 			("circular", value<bool>(&circular)->default_value(false)->implicit_value(true),
 			 "Write output to a circular buffer which is saved on exit")
+			("frames", value<unsigned int>(&frames)->default_value(0),
+			 "Run for the exact number of frames specified. This will override any timeout set.")
 			;
 	}
 
@@ -70,6 +72,7 @@ struct VideoOptions : public Options
 	bool split;
 	uint32_t segment;
 	bool circular;
+	uint32_t frames;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{

--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -41,7 +41,8 @@ private:
 	// re-use.
 	void outputThread();
 
-	bool abort_;
+	bool abortPoll_;
+	bool abortOutput_;
 	int fd_;
 	struct BufferDescription
 	{

--- a/encoder/mjpeg_encoder.hpp
+++ b/encoder/mjpeg_encoder.hpp
@@ -37,7 +37,8 @@ private:
 	// re-use.
 	void outputThread();
 
-	bool abort_;
+	bool abortEncode_;
+	bool abortOutput_;
 	uint64_t index_;
 
 	struct EncodeItem


### PR DESCRIPTION
…rames

This will allow users to encode (mjpeg/H.264) an exact number of frames without
relying on timeouts which have a bit of variability.

The --frames option will take precedence over any timout specified on the
command line.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>