### PR TITLE
output: Upgrade circular buffer output for 64-bit systems

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -49,8 +49,8 @@ struct VideoOptions : public Options
 			 "Create a new output file every time recording is paused and then resumed")
 			("segment", value<uint32_t>(&segment)->default_value(0),
 			 "Break the recording into files of approximately this many milliseconds")
-			("circular", value<bool>(&circular)->default_value(false)->implicit_value(true),
-			 "Write output to a circular buffer which is saved on exit")
+			("circular", value<size_t>(&circular)->default_value(0)->implicit_value(4),
+			 "Write output to a circular buffer of the given size (in MB) which is saved on exit")
 			("frames", value<unsigned int>(&frames)->default_value(0),
 			 "Run for the exact number of frames specified. This will override any timeout set.")
 			;
@@ -71,7 +71,7 @@ struct VideoOptions : public Options
 	bool pause;
 	bool split;
 	uint32_t segment;
-	bool circular;
+	size_t circular;
 	uint32_t frames;
 
 	virtual bool Parse(int argc, char *argv[]) override

--- a/output/circular_output.cpp
+++ b/output/circular_output.cpp
@@ -7,8 +7,6 @@
 
 #include "circular_output.hpp"
 
-static constexpr int CIRCULAR_BUFFER_SIZE = 1 << 22; // 4MB, we could consider this more carefully...
-
 // We're going to align the frames within the buffer to friendly byte boundaries
 static constexpr int ALIGN = 16; // power of 2, please
 
@@ -20,7 +18,8 @@ struct Header
 };
 static_assert(sizeof(Header) % ALIGN == 0, "Header should have aligned size");
 
-CircularOutput::CircularOutput(VideoOptions const *options) : Output(options), cb_(CIRCULAR_BUFFER_SIZE)
+// Size of buffer (options->circular) is given in megabytes.
+CircularOutput::CircularOutput(VideoOptions const *options) : Output(options), cb_(options->circular<<20)
 {
 	// Open this now, so that we can get any complaints out of the way
 	fp_ = fopen(options_->output.c_str(), "w");

--- a/output/circular_output.hpp
+++ b/output/circular_output.hpp
@@ -14,9 +14,9 @@
 class CircularBuffer
 {
 public:
-	CircularBuffer(unsigned int size) : size_(size), buf_(size), rptr_(0), wptr_(0) {}
+	CircularBuffer(size_t size) : size_(size), buf_(size), rptr_(0), wptr_(0) {}
 	bool Empty() const { return rptr_ == wptr_; }
-	unsigned int Available() const { return (size_ - wptr_ + rptr_) % size_ - 1; }
+	size_t Available() const { return (size_ - wptr_ + rptr_) % size_ - 1; }
 	void Skip(unsigned int n) { rptr_ = (rptr_ + n) % size_; }
 	// The dst function allows bytes read to go straight to memory or a file etc.
 	void Read(std::function<void(void *src, unsigned int n)> dst, unsigned int n)
@@ -45,9 +45,9 @@ public:
 	}
 
 private:
-	const unsigned int size_;
+	const size_t size_;
 	std::vector<uint8_t> buf_;
-	unsigned int rptr_, wptr_;
+	size_t rptr_, wptr_;
 };
 
 // Write frames to a circular buffer, and dump them to disk when we quit.


### PR DESCRIPTION
The buffer can now be > 4GB. The buffer size can also be specified on
the command line with the --circular option.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>