### PR TITLE
options: Do not run clang format on the options structures.

### DIFF
--- a/core/options.hpp
+++ b/core/options.hpp
@@ -38,6 +38,7 @@ struct Options
 	Options() : options_("Valid options are", 120, 80)
 	{
 		using namespace boost::program_options;
+		// clang-format off
 		options_.add_options()
 			("help,h", value<bool>(&help)->default_value(false)->implicit_value(true),
 			 "Print this help message")
@@ -129,6 +130,7 @@ struct Options
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			;
+		// clang-format on
 	}
 
 	virtual ~Options() {}

--- a/core/still_options.hpp
+++ b/core/still_options.hpp
@@ -16,6 +16,7 @@ struct StillOptions : public Options
 	StillOptions() : Options()
 	{
 		using namespace boost::program_options;
+		// clang-format off
 		options_.add_options()
 			("quality,q", value<int>(&quality)->default_value(93),
 			 "Set the JPEG quality parameter")
@@ -46,6 +47,7 @@ struct StillOptions : public Options
 			("immediate", value<bool>(&immediate)->default_value(false)->implicit_value(true),
 			 "Perform first capture immediately, with no preview phase")
 			;
+		// clang-format on
 	}
 
 	int quality;

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -20,6 +20,7 @@ struct VideoOptions : public Options
 		using namespace boost::program_options;
 		// Generally we shall use zero or empty values to avoid over-writing the
 		// codec's default behaviour.
+		// clang-format off
 		options_.add_options()
 			("bitrate,b", value<uint32_t>(&bitrate)->default_value(0),
 			 "Set the bitrate for encoding, in bits/second (h264 only)")
@@ -54,6 +55,7 @@ struct VideoOptions : public Options
 			("frames", value<unsigned int>(&frames)->default_value(0),
 			 "Run for the exact number of frames specified. This will override any timeout set.")
 			;
+		// clang-format on
 	}
 
 	uint32_t bitrate;


### PR DESCRIPTION
clang-format does not like this type of formatting, so keep the checkstyle
script from complaining on these blocks.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>