### PR TITLE
libcamera-still: Implement wrap feature

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -104,6 +104,8 @@ static void save_images(LibcameraStillApp &app, CompletedRequestPtr &payload)
 		save_image(app, payload, app.RawStream(), filename);
 	}
 	options->framestart++;
+	if (options->wrap)
+		options->framestart %= options->wrap;
 }
 
 // Some keypress/signal handling.


### PR DESCRIPTION
The "wrap" option for the filename counter had not been implemented
for libcamera-still.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>