### PR TITLE
core: Fix build breakage after libcamera API changes.

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -671,9 +671,9 @@ void LibcameraApp::setupCapture()
 			{
 				const FrameBuffer::Plane &plane = buffer->planes()[i];
 				buffer_size += plane.length;
-				if (i == buffer->planes().size() - 1 || plane.fd.fd() != buffer->planes()[i + 1].fd.fd())
+				if (i == buffer->planes().size() - 1 || plane.fd.get() != buffer->planes()[i + 1].fd.get())
 				{
-					void *memory = mmap(NULL, buffer_size, PROT_READ | PROT_WRITE, MAP_SHARED, plane.fd.fd(), 0);
+					void *memory = mmap(NULL, buffer_size, PROT_READ | PROT_WRITE, MAP_SHARED, plane.fd.get(), 0);
 					mapped_buffers_[buffer.get()].push_back(
 						libcamera::Span<uint8_t>(static_cast<uint8_t *>(memory), buffer_size));
 					buffer_size = 0;
@@ -783,7 +783,7 @@ void LibcameraApp::previewThread()
 		frame_info.fps = item.completed_request->framerate;
 		frame_info.sequence = item.completed_request->sequence;
 
-		int fd = buffer->planes()[0].fd.fd();
+		int fd = buffer->planes()[0].fd.get();
 		{
 			std::lock_guard<std::mutex> lock(preview_mutex_);
 			// the reference to the shared_ptr moves to the map here

--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -42,7 +42,7 @@ public:
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);
 			encode_buffer_queue_.push(completed_request); // creates a new reference
 		}
-		encoder_->EncodeBuffer(buffer->planes()[0].fd.fd(), span.size(), mem, w, h, stride, timestamp_ns / 1000);
+		encoder_->EncodeBuffer(buffer->planes()[0].fd.get(), span.size(), mem, w, h, stride, timestamp_ns / 1000);
 	}
 	VideoOptions *GetOptions() const { return static_cast<VideoOptions *>(options_.get()); }
 	void StopEncoder() { encoder_.reset(); }


### PR DESCRIPTION
The following libcamera API change breaks the libcamera-apps builds:
commit 560f5cf998646ddc54a20dc1c7326012834d3204
Author: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
Date:   Mon Nov 29 20:38:10 2021 +0200

    libcamera: base: shared_fd: Rename fd() to get()

    For consistency with UniqueFD, rename the fd() function to get().
    Renaming UniqueFD::get() to fd() would have been another option, but was
    rejected to keep as close as possible to the std::shared_ptr<> and
    std::unique_ptr<> APIs.

    Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
    Reviewed-by: Jacopo Mondi <jacopo@jmondi.org>
    Reviewed-by: Hirokazu Honda <hiroh@chromium.org>

Fix the breakage by using plane.fd.get() instead of plane.fd.fd().

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>