### PR TITLE
h264: Tidy up the encoder properly when it shuts

### DIFF
--- a/encoder/h264_encoder.hpp
+++ b/encoder/h264_encoder.hpp
@@ -50,6 +50,7 @@ private:
 		size_t size;
 	};
 	BufferDescription buffers_[NUM_CAPTURE_BUFFERS];
+	int num_capture_buffers_;
 	std::thread poll_thread_;
 	std::mutex input_buffers_available_mutex_;
 	std::queue<int> input_buffers_available_;


### PR DESCRIPTION
This means you can close and open the h264 encoder multiple times
without eventually running out of CMA.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>