### PR TITLE
Allow circular output to write to stdout

### DIFF
--- a/output/circular_output.cpp
+++ b/output/circular_output.cpp
@@ -22,7 +22,12 @@ static_assert(sizeof(Header) % ALIGN == 0, "Header should have aligned size");
 CircularOutput::CircularOutput(VideoOptions const *options) : Output(options), cb_(options->circular<<20)
 {
 	// Open this now, so that we can get any complaints out of the way
-	fp_ = fopen(options_->output.c_str(), "w");
+	if (options_->output == "-")
+		fp_ = stdout;
+	else if (!options_->output.empty())
+	{
+		fp_ = fopen(options_->output.c_str(), "w");
+	}
 	if (!fp_)
 		throw std::runtime_error("could not open output file");
 }


### PR DESCRIPTION
Can be tested with: 
```
libcamera-vid --circular 1000 --frames 60 --framerate 30 --width 1920 --height 1080 --codec yuv420 -o - \
| pv -r > /dev/null
```
And allows for piping to FFmpeg/Gstreamer, with the purpose of holding the encode until all frames have been captured (up to the amount that can fit in circular ram buffer):
```
libcamera-vid --circular 1000 --frames 60 --framerate 30 --width 1920 --height 1080 --codec yuv420 -o - \
| ffmpeg -y -f rawvideo -pix_fmt yuv420p -s:v 1920x1080 -r 30 -i - -c:v h264_v4l2m2m -b:v 25M ~/out.mp4
```