### PR TITLE
core: Stop preview thread in Teardown method

### DIFF
--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -175,6 +175,8 @@ private:
 	void queueRequest(CompletedRequest *completed_request);
 	void requestComplete(Request *request);
 	void previewDoneCallback(int fd);
+	void startPreview();
+	void stopPreview();
 	void previewThread();
 	void configureDenoise(const std::string &denoise_mode);
 


### PR DESCRIPTION
This means it can't access buffers that are being deallocated when the
display is very laggy (such as when using VNC). Correspondingly, the
preview thread is started at the end of the Configure methods.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>