### PR TITLE
libcamera-vid: Signals were not being "cancelled" in signal mode

### DIFF
--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -45,6 +45,7 @@ static int get_key_or_signal(VideoOptions const *options, pollfd p[1])
 			key = '\n';
 		else if (signal_received == SIGUSR2)
 			key = 'x';
+		signal_received = 0;
 	}
 	return key;
 }


### PR DESCRIPTION
This copies a previous fix in libcamera-still (fa95bcb), which applies
here too.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>