### PR TITLE
preview: Preview was not resuming properly during timelapse

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -478,9 +478,6 @@ void LibcameraApp::StopCamera()
 
 	msg_queue_.Clear();
 
-	if (preview_)
-		preview_->Reset();
-
 	while (!free_requests_.empty())
 		free_requests_.pop();
 
@@ -753,6 +750,7 @@ void LibcameraApp::previewDoneCallback(int fd)
 
 void LibcameraApp::startPreview()
 {
+	preview_abort_ = false;
 	preview_thread_ = std::thread(&LibcameraApp::previewThread, this);
 }
 
@@ -778,7 +776,10 @@ void LibcameraApp::previewThread()
 		{
 			std::unique_lock<std::mutex> lock(preview_item_mutex_);
 			if (preview_abort_)
+			{
+				preview_->Reset();
 				return;
+			}
 			else if (preview_item_.stream)
 				item = std::move(preview_item_); // re-use existing shared_ptr reference
 			else

--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -413,6 +413,8 @@ void EglPreview::Reset()
 		glDeleteTextures(1, &it.second.texture);
 	buffers_.clear();
 	last_fd_ = -1;
+	eglMakeCurrent(egl_display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	first_time_ = true;
 }
 
 bool EglPreview::Quit()


### PR DESCRIPTION
A preview fix (9d89e1e) actually broke this. There was a particularly
subtle issue with EGL where it was still only obeying the previous
preview thread which has stopped running.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>