### PR TITLE
core: Rationalise handling of free_requests_ and known_completed_requ…

### DIFF
--- a/core/completed_request.hpp
+++ b/core/completed_request.hpp
@@ -18,14 +18,17 @@ struct CompletedRequest
 {
 	using BufferMap = libcamera::Request::BufferMap;
 	using ControlList = libcamera::ControlList;
+	using Request = libcamera::Request;
 
-	CompletedRequest(unsigned int seq, BufferMap const &b, ControlList const &m)
-		: sequence(seq), buffers(b), metadata(m)
+	CompletedRequest(unsigned int seq, Request *r)
+		: sequence(seq), buffers(r->buffers()), metadata(r->metadata()), request(r)
 	{
+		r->reuse();
 	}
 	unsigned int sequence;
 	BufferMap buffers;
 	ControlList metadata;
+	Request *request;
 	float framerate;
 	Metadata post_process_metadata;
 };

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -187,10 +187,9 @@ private:
 	std::map<std::string, Stream *> streams_;
 	FrameBufferAllocator *allocator_ = nullptr;
 	std::map<Stream *, std::queue<FrameBuffer *>> frame_buffers_;
-	std::mutex free_requests_mutex_;
-	std::queue<Request *> free_requests_;
 	std::vector<std::unique_ptr<Request>> requests_;
-	std::set<CompletedRequest *> known_completed_requests_;
+	std::mutex completed_requests_mutex_;
+	std::set<CompletedRequest *> completed_requests_;
 	bool camera_started_ = false;
 	std::mutex camera_stop_mutex_;
 	MessageQueue<Msg> msg_queue_;


### PR DESCRIPTION
…ests_

Firstly, known_completed_requests_ was not being protected by a mutex
(like free_requests_) and should have been. But moreover, we can
dispense with the free_requests_ list completely if the
CompletedRequest contains a pointer to the libcamera Request object,
and this tidies up the whole "queue another Request when the
CompletedRequest is dropped" logic (in LibcameraApp::queueRequest).

In fact we could go further and leave the BufferMap and metadata in
the Request (not copying it to the CompletedRequest), but that would
touch quite a few files so we can save it for another time.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>