### PR TITLE
options: Support "long" exposure mode

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -153,7 +153,7 @@ bool Options::Parse(int argc, char *argv[])
 		{ { "normal", libcamera::controls::ExposureNormal },
 			{ "sport", libcamera::controls::ExposureShort },
 			{ "short", libcamera::controls::ExposureShort },
-			// long mode?
+			{ "long", libcamera::controls::ExposureLong },
 			{ "custom", libcamera::controls::ExposureCustom } };
 	if (exposure_table.count(exposure) == 0)
 		throw std::runtime_error("Invalid exposure mode:" + exposure);


### PR DESCRIPTION
The exposure options did not include this, so it has been added.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>