### PR TITLE
preview: Clear the preview item queue when we stop the preview

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -759,6 +759,7 @@ void LibcameraApp::stopPreview()
 		preview_cond_var_.notify_one();
 	}
 	preview_thread_.join();
+	preview_item_ = PreviewItem();
 }
 
 void LibcameraApp::previewThread()


### PR DESCRIPTION
preview_item_ is effectively a 1-deep queue of frames still to
display. It's best to clear this when the preview is stopped so that
there's no way that anyone might attempt to display it if the preview
restarts (by which time it would be stale).

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>