### PR TITLE
Include sstream header

### DIFF
--- a/core/frame_info.hpp
+++ b/core/frame_info.hpp
@@ -6,6 +6,7 @@
  */
 #include <array>
 #include <iomanip>
+#include <sstream>
 #include <string>
 
 #include <libcamera/control_ids.h>


### PR DESCRIPTION
Fix for clang fatal error: implicit instantiation of undefined template 'std::basic_stringstream<char>'