### PR TITLE
post_processor: Only start it once the camera is successfully started

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -441,13 +441,13 @@ void LibcameraApp::StartCamera()
 	if (!controls_.contains(controls::Sharpness))
 		controls_.set(controls::Sharpness, options_->sharpness);
 
-	post_processor_.Start();
-
 	if (camera_->start(&controls_))
 		throw std::runtime_error("failed to start camera");
 	controls_.clear();
 	camera_started_ = true;
 	last_timestamp_ = 0;
+
+	post_processor_.Start();
 
 	camera_->requestCompleted.connect(this, &LibcameraApp::requestComplete);
 


### PR DESCRIPTION
Previously if the camera failed to start, but the post processor was
already started, StopCamera() would have failed to clean up the post
processor properly. There's no harm in starting it after, the
requestComplete() callback can't be invoked before it's connected.

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>