### PR TITLE
Timeout Warning & Build Instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # libcamera-apps
 
-This is a small suite of libcamera-based apps that aim to copy the functionality of the existing "raspicam" apps. For usage and build instructions, see the official Raspberry Pi documenation pages [here.](https://www.raspberrypi.com/documentation/accessories/camera.html#libcamera-and-libcamera-apps)
+This is a small suite of libcamera-based apps that aim to copy the functionality of the existing "raspicam" apps.
+
+Build Instructions
+------------------
+
+For usage and build instructions, see the official Raspberry Pi documenation pages [here.](https://www.raspberrypi.com/documentation/accessories/camera.html#libcamera-and-libcamera-apps)
 
 License
 -------

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -97,8 +97,7 @@ static void event_loop(LibcameraEncoder &app)
 		if (timeout || frameout || key == 'x' || key == 'X')
 		{
 		        if (timeout)
-			  std::cout << "Halting: reached timeout of " << options->timeout
-				    << " milleseconds.\n";
+			        std::cout << "Halting: reached timeout of " << options->timeout << " milliseconds.\n";
 			
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -97,8 +97,8 @@ static void event_loop(LibcameraEncoder &app)
 		if (timeout || frameout || key == 'x' || key == 'X')
 		{
 		        if (timeout)
-			        std::cout << "Halting: reached timeout of " << options->timeout << " milliseconds.\n";
-			
+				std::cout << "Halting: reached timeout of " << options->timeout << " milliseconds.\n";
+
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();
 			return;

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -96,6 +96,10 @@ static void event_loop(LibcameraEncoder &app)
 		bool frameout = options->frames && count >= options->frames;
 		if (timeout || frameout || key == 'x' || key == 'X')
 		{
+		        if (timeout)
+			  std::cout << "Halting: reached timeout of " << options->timeout
+				    << " milleseconds.\n";
+			
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();
 			return;

--- a/core/frame_info.hpp
+++ b/core/frame_info.hpp
@@ -6,6 +6,7 @@
  */
 #include <array>
 #include <iomanip>
+#include <sstream>
 #include <string>
 
 #include <libcamera/control_ids.h>


### PR DESCRIPTION
1) prints to console timeout value, if previously set and causing the termination of the process
2) isolated Build instructions with its own heading.  In text mode, a link at the end of an introductory paragraph can be missed.

This is my second pull request, the previous one failed because I had not correctly run checkstyle.py _after_ committing rather than before.