### PR TITLE
Isolated build instructions so link is more prominent in a text mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # libcamera-apps
 
-This is a small suite of libcamera-based apps that aim to copy the functionality of the existing "raspicam" apps. For usage and build instructions, see the official Raspberry Pi documenation pages [here.](https://www.raspberrypi.com/documentation/accessories/camera.html#libcamera-and-libcamera-apps)
+This is a small suite of libcamera-based apps that aim to copy the functionality of the existing "raspicam" apps. 
+
+Build
+-----
+For usage and build instructions, see the official Raspberry Pi documenation pages [here.](https://www.raspberrypi.com/documentation/accessories/camera.html#libcamera-and-libcamera-apps)
 
 License
 -------

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -96,6 +96,8 @@ static void event_loop(LibcameraEncoder &app)
 		bool frameout = options->frames && count >= options->frames;
 		if (timeout || frameout || key == 'x' || key == 'X')
 		{
+			if (timeout)
+				std::cerr << "Halting: reached timeout of " << options->timeout << " milliseconds.\n";
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();
 			return;


### PR DESCRIPTION
Since build instructions are maintained within another doc that is linked to, highlighted by added subtitle "Build" so reader in text mode sees that another document should be referenced.