### PR TITLE
preview: fix egl_preview compile (conversion from Window to EGLNative…

### DIFF
--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -326,7 +326,7 @@ void EglPreview::makeWindow(char const *name)
 	wm_delete_window_ = XInternAtom(display_, "WM_DELETE_WINDOW", False);
 	XSetWMProtocols(display_, window_, &wm_delete_window_, 1);
 
-	egl_surface_ = eglCreateWindowSurface(egl_display_, config, window_, NULL);
+	egl_surface_ = eglCreateWindowSurface(egl_display_, config, reinterpret_cast<EGLNativeWindowType>(window_), NULL);
 	if (!egl_surface_)
 		throw std::runtime_error("eglCreateWindowSurface failed");
 


### PR DESCRIPTION
…WindowType)

Fixes:

  .../build/libcamera-apps-2d1009e3badcc8047361ff81149ad6cba3b911b5/preview/egl_preview.cpp:329:69: error: invalid conversion from ‘Window’ {aka ‘long unsigned int’} to ‘EGLNativeWindowType’ {aka ‘fbdev_window*’} [-fpermissive]
    329 |         egl_surface_ = eglCreateWindowSurface(egl_display_, config, window_, NULL);
        |                                                                     ^~~~~~~
        |                                                                     |
        |                                                                     Window {aka long unsigned int}

Signed-off-by: Peter Seiderer <ps.report@gmx.net>
---
Notes:
  - original buildroot autobuild failure (after fixing the missing libdrm dependency)
    http://autobuild.buildroot.net/results/5df48038df5deb4f1e85287cde9a403c5681c28e

  - fix inspired by same/similare problem/fix in qtwayland
    https://code.qt.io/cgit/qt/qtwayland.git/commit/?id=8b204b2c56be5e7c1fd21144ae140c9b865dd86b