### PR TITLE
Use controls::SensorTimestamp for timestamps if possible.

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -729,7 +729,11 @@ void LibcameraApp::requestComplete(Request *request)
 	}
 
 	// We calculate the instantaneous framerate in case anyone wants it.
-	uint64_t timestamp = payload->buffers.begin()->second->metadata().timestamp;
+	// Use the sensor timestamp if possible as it ought to be less glitchy than
+	// the buffer timestamps.
+	uint64_t timestamp = payload->metadata.contains(controls::SensorTimestamp)
+							? payload->metadata.get(controls::SensorTimestamp)
+							: payload->buffers.begin()->second->metadata().timestamp;
 	if (last_timestamp_ == 0 || last_timestamp_ == timestamp)
 		payload->framerate = 0;
 	else

--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -38,7 +38,9 @@ public:
 		void *mem = span.data();
 		if (!buffer || !mem)
 			throw std::runtime_error("no buffer to encode");
-		int64_t timestamp_ns = buffer->metadata().timestamp;
+		int64_t timestamp_ns = completed_request->metadata.contains(controls::SensorTimestamp)
+								? completed_request->metadata.get(controls::SensorTimestamp)
+								: buffer->metadata().timestamp;
 		{
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);
 			encode_buffer_queue_.push(completed_request); // creates a new reference


### PR DESCRIPTION
Framebuffer timestamps account for SW overheads and pipelining, so might be a
bit glitchy.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>