### PR TITLE
libcamera-still: Allow --immediate and keypress/signal to work together

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -4,7 +4,7 @@
  *
  * libcamera_still.cpp - libcamera stills capture app.
  */
-
+#include <chrono>
 #include <poll.h>
 #include <signal.h>
 #include <sys/signalfd.h>
@@ -17,6 +17,7 @@
 
 #include "image/image.hpp"
 
+using namespace std::chrono_literals;
 using namespace std::placeholders;
 using libcamera::Stream;
 
@@ -155,8 +156,25 @@ static void event_loop(LibcameraStillApp &app)
 		still_flags |= LibcameraApp::FLAG_STILL_RAW;
 
 	app.OpenCamera();
+
+	// Monitoring for keypresses and signals.
+	signal(SIGUSR1, default_signal_handler);
+	signal(SIGUSR2, default_signal_handler);
+	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
+
 	if (options->immediate)
+	{
 		app.ConfigureStill(still_flags);
+		while (keypress)
+		{
+			int key = get_key_or_signal(options, p);
+			if (key == 'x' || key == 'X')
+				return;
+			else if (key == '\n')
+				break;
+			std::this_thread::sleep_for(10ms);
+		}
+	}
 	else
 		app.ConfigureViewfinder();
 	app.StartCamera();
@@ -164,11 +182,6 @@ static void event_loop(LibcameraStillApp &app)
 	auto timelapse_time = start_time;
 	int timelapse_frames = 0;
 	constexpr int TIMELAPSE_MIN_FRAMES = 6; // at least this many preview frames between captures
-
-	// Monitoring for keypresses and signals.
-	signal(SIGUSR1, default_signal_handler);
-	signal(SIGUSR2, default_signal_handler);
-	pollfd p[1] = { { STDIN_FILENO, POLLIN, 0 } };
 
 	for (unsigned int count = 0; ; count++)
 	{
@@ -227,7 +240,7 @@ static void event_loop(LibcameraStillApp &app)
 			std::cerr << "Still capture image received" << std::endl;
 			save_images(app, std::get<CompletedRequestPtr>(msg.payload));
 			timelapse_frames = 0;
-			if (options->timelapse || options->signal || options->keypress)
+			if (!options->immediate && (options->timelapse || options->signal || options->keypress))
 			{
 				app.Teardown();
 				app.ConfigureViewfinder();


### PR DESCRIPTION
These command line arguments set together would not do the expected thing.
Fix this by having a wait loop after configuring stills mode and wait for the
signal/keypress before taking the capture.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>