### PR TITLE
encoder: Add a cmake command line option to disable libav

### DIFF
--- a/encoder/CMakeLists.txt
+++ b/encoder/CMakeLists.txt
@@ -2,25 +2,32 @@ cmake_minimum_required(VERSION 3.6)
 
 include(GNUInstallDirs)
 
+if (NOT DEFINED ENABLE_LIBAV)
+    set(ENABLE_LIBAV 1)
+endif()
+
 set(LIBAV_PRESENT 0)
 set(SRC encoder.cpp null_encoder.cpp h264_encoder.cpp mjpeg_encoder.cpp)
 set(TARGET_LIBS images)
 
-#pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET ffspeg)
-pkg_check_modules(LIBAV QUIET IMPORTED_TARGET
-    libavcodec
-    libavdevice
-    libavformat
-    libswresample
-)
-
-if (LIBAV_FOUND)
-    include_directories(${LIBAV_INCLUDE_DIRS})
-    set(SRC ${SRC} libav_encoder.cpp)
-    set(TARGET_LIBS ${TARGET_LIBS} ${LIBAV_LIBRARIES})
-    set(LIBAV_PRESENT 1)
-    message(STATUS "libavcodec found:")
-    message(STATUS "    libraries: ${LIBAV_LIBRARIES}")
+if (ENABLE_LIBAV)
+    message(STATUS "Checking for libavcodec")
+    pkg_check_modules(LIBAV QUIET IMPORTED_TARGET
+        libavcodec
+        libavdevice
+        libavformat
+        libswresample
+    )
+    if (LIBAV_FOUND)
+        include_directories(${LIBAV_INCLUDE_DIRS})
+        set(SRC ${SRC} libav_encoder.cpp)
+        set(TARGET_LIBS ${TARGET_LIBS} ${LIBAV_LIBRARIES})
+        set(LIBAV_PRESENT 1)
+        message(STATUS "libavcodec found:")
+        message(STATUS "    libraries: ${LIBAV_LIBRARIES}")
+    endif()
+else()
+    message(STATUS "Omitting libavcodec")
 endif()
 
 add_library(encoders ${SRC})


### PR DESCRIPTION
Use cmake ... -DENABLE_LIBAV=0 to disable linking in libav and disabling the
functionality.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>