### PR TITLE
output: Circular Buffer only save timestamps for used frames

### DIFF
--- a/output/circular_output.cpp
+++ b/output/circular_output.cpp
@@ -55,6 +55,10 @@ CircularOutput::~CircularOutput()
 			cb_.Read([fp](void *src, int n) { fwrite(src, 1, n, fp); }, header.length);
 			cb_.Skip((ALIGN - header.length) & (ALIGN - 1));
 			total += header.length;
+			if (fp_timestamps_)
+			{
+				Output::timestampReady(header.timestamp);
+			}
 			frames++;
 		}
 		else
@@ -86,4 +90,9 @@ void CircularOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, 
 	cb_.Write(&header, sizeof(header));
 	cb_.Write(mem, size);
 	cb_.Pad(pad);
+}
+
+void CircularOutput::timestampReady(int64_t timestamp)
+{
+	// Don't want to save every timestamp as we go along, only outputs them at the end
 }

--- a/output/circular_output.hpp
+++ b/output/circular_output.hpp
@@ -60,6 +60,7 @@ public:
 
 protected:
 	void outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t flags) override;
+	void timestampReady(int64_t timestamp) override;
 
 private:
 	CircularBuffer cb_;

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -14,7 +14,7 @@
 #include "output.hpp"
 
 Output::Output(VideoOptions const *options)
-	: options_(options), state_(WAITING_KEYFRAME), fp_timestamps_(nullptr), time_offset_(0), last_timestamp_(0)
+	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0)
 {
 	if (!options->save_pts.empty())
 	{
@@ -60,7 +60,16 @@ void Output::OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyf
 
 	// Save timestamps to a file, if that was requested.
 	if (fp_timestamps_)
-		fprintf(fp_timestamps_, "%" PRId64 ".%03" PRId64 "\n", last_timestamp_ / 1000, last_timestamp_ % 1000);
+	{
+		timestampReady(last_timestamp_);
+	}
+}
+
+void Output::timestampReady(int64_t timestamp)
+{
+	fprintf(fp_timestamps_, "%" PRId64 ".%03" PRId64 "\n", timestamp / 1000, timestamp % 1000);
+	if (options_->flush)
+		fflush(fp_timestamps_);
 }
 
 void Output::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t flags)

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -31,7 +31,9 @@ protected:
 		FLAG_RESTART = 2
 	};
 	virtual void outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t flags);
+	virtual void timestampReady(int64_t timestamp);
 	VideoOptions const *options_;
+	FILE *fp_timestamps_;
 
 private:
 	enum State
@@ -42,7 +44,6 @@ private:
 	};
 	State state_;
 	std::atomic<bool> enable_;
-	FILE *fp_timestamps_;
 	int64_t time_offset_;
 	int64_t last_timestamp_;
 };


### PR DESCRIPTION
When using a circular buffer output and saving the timestamps to a file,
only save the timestamps for the frames which have been saved, rather
than saving all the timestamps even for frames no longer in the buffer.

Also allow --flush to flush the pts values to a file.

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>