### PR TITLE
Add verbosity levels

### DIFF
--- a/apps/libcamera_detect.cpp
+++ b/apps/libcamera_detect.cpp
@@ -86,7 +86,7 @@ static void event_loop(LibcameraDetectApp &app)
 				app.Teardown();
 				app.ConfigureStill();
 				app.StartCamera();
-				std::cerr << options->object << " detected" << std::endl;
+				LOG(1, options->object << " detected");
 			}
 		}
 		// In still capture mode, save a jpeg and go back to preview.
@@ -104,7 +104,7 @@ static void event_loop(LibcameraDetectApp &app)
 			snprintf(filename, sizeof(filename), options->output.c_str(), options->framestart);
 			filename[sizeof(filename) - 1] = 0;
 			options->framestart++;
-			std::cerr << "Save image " << filename << std::endl;
+			LOG(1, "Save image " << filename);
 			jpeg_save(mem, info, completed_request->metadata, std::string(filename), app.CameraId(), options);
 
 			// Restart camera in preview mode.
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_detect.cpp
+++ b/apps/libcamera_detect.cpp
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 		DetectOptions *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 			if (options->output.empty())
 				throw std::runtime_error("output file name required");

--- a/apps/libcamera_hello.cpp
+++ b/apps/libcamera_hello.cpp
@@ -32,8 +32,7 @@ static void event_loop(LibcameraApp &app)
 		else if (msg.type != LibcameraApp::MsgType::RequestComplete)
 			throw std::runtime_error("unrecognised message!");
 
-		if (options->verbose >= 2)
-			std::cerr << "Viewfinder frame " << count << std::endl;
+		LOG(2, "Viewfinder frame " << count);
 		auto now = std::chrono::high_resolution_clock::now();
 		if (options->timeout && now - start_time > std::chrono::milliseconds(options->timeout))
 			return;
@@ -59,7 +58,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_hello.cpp
+++ b/apps/libcamera_hello.cpp
@@ -32,7 +32,7 @@ static void event_loop(LibcameraApp &app)
 		else if (msg.type != LibcameraApp::MsgType::RequestComplete)
 			throw std::runtime_error("unrecognised message!");
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Viewfinder frame " << count << std::endl;
 		auto now = std::chrono::high_resolution_clock::now();
 		if (options->timeout && now - start_time > std::chrono::milliseconds(options->timeout))
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 		Options *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 
 			event_loop(app);

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -69,7 +69,8 @@ static void event_loop(LibcameraJpegApp &app)
 		else if (app.StillStream())
 		{
 			app.StopCamera();
-			std::cerr << "Still capture image received" << std::endl;
+			if (options->verbose >= 1)
+				std::cerr << "Still capture image received" << std::endl;
 
 			Stream *stream = app.StillStream();
 			StreamInfo info = app.GetStreamInfo(stream);
@@ -89,7 +90,7 @@ int main(int argc, char *argv[])
 		StillOptions *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 			if (options->output.empty())
 				throw std::runtime_error("output file name required");

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -69,8 +69,7 @@ static void event_loop(LibcameraJpegApp &app)
 		else if (app.StillStream())
 		{
 			app.StopCamera();
-			if (options->verbose >= 1)
-				std::cerr << "Still capture image received" << std::endl;
+			LOG(1, "Still capture image received");
 
 			Stream *stream = app.StillStream();
 			StreamInfo info = app.GetStreamInfo(stream);
@@ -100,7 +99,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_raw.cpp
+++ b/apps/libcamera_raw.cpp
@@ -50,7 +50,7 @@ static void event_loop(LibcameraRaw &app)
 					  << " format " << cfg.pixelFormat.toString() << std::endl;
 		}
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Viewfinder frame " << count << std::endl;
 		auto now = std::chrono::high_resolution_clock::now();
 		if (options->timeout && now - start_time > std::chrono::milliseconds(options->timeout))
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
 		{
 			options->denoise = "cdn_off";
 			options->nopreview = true;
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 
 			event_loop(app);

--- a/apps/libcamera_raw.cpp
+++ b/apps/libcamera_raw.cpp
@@ -46,12 +46,11 @@ static void event_loop(LibcameraRaw &app)
 		if (count == 0)
 		{
 			libcamera::StreamConfiguration const &cfg = app.RawStream()->configuration();
-			std::cerr << "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride
-					  << " format " << cfg.pixelFormat.toString() << std::endl;
+			LOG(1, "Raw stream: " << cfg.size.width << "x" << cfg.size.height << " stride " << cfg.stride << " format "
+								  << cfg.pixelFormat.toString());
 		}
 
-		if (options->verbose >= 2)
-			std::cerr << "Viewfinder frame " << count << std::endl;
+		LOG(2, "Viewfinder frame " << count);
 		auto now = std::chrono::high_resolution_clock::now();
 		if (options->timeout && now - start_time > std::chrono::milliseconds(options->timeout))
 		{
@@ -82,7 +81,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -60,13 +60,13 @@ static void update_latest_link(std::string const &filename, StillOptions const *
 	{
 		struct stat buf;
 		if (stat(options->latest.c_str(), &buf) == 0 && unlink(options->latest.c_str()))
-			std::cerr << "WARNING: could not delete latest link " << options->latest << std::endl;
+			LOG_ERROR("WARNING: could not delete latest link " << options->latest);
 		else
 		{
 			if (symlink(filename.c_str(), options->latest.c_str()))
-				std::cerr << "WARNING: failed to create latest link " << options->latest << std::endl;
-			else if (options->verbose >= 2)
-				std::cerr << "Link " << options->latest << " created" << std::endl;
+				LOG_ERROR("WARNING: failed to create latest link " << options->latest);
+			else
+				LOG(2, "Link " << options->latest << " created");
 		}
 	}
 }
@@ -87,8 +87,7 @@ static void save_image(LibcameraStillApp &app, CompletedRequestPtr &payload, Str
 		bmp_save(mem, info, filename, options);
 	else
 		yuv_save(mem, info, filename, options);
-	if (options->verbose >= 2)
-		std::cerr << "Saved image " << info.width << " x " << info.height << " to file " << filename << std::endl;
+	LOG(2, "Saved image " << info.width << " x " << info.height << " to file " << filename);
 }
 
 static void save_images(LibcameraStillApp &app, CompletedRequestPtr &payload)
@@ -130,7 +129,7 @@ static int signal_received;
 static void default_signal_handler(int signal_number)
 {
 	signal_received = signal_number;
-	std::cerr << "Received signal " << signal_number << std::endl;
+	LOG(1, "Received signal " << signal_number);
 }
 static int get_key_or_signal(StillOptions const *options, pollfd p[1])
 {
@@ -217,8 +216,7 @@ static void event_loop(LibcameraStillApp &app)
 		// capture mode if an output was requested.
 		if (app.ViewfinderStream())
 		{
-			if (options->verbose >= 2)
-				std::cerr << "Viewfinder frame " << count << std::endl;
+			LOG(2, "Viewfinder frame " << count);
 			timelapse_frames++;
 
 			bool timed_out = options->timeout && now - start_time > std::chrono::milliseconds(options->timeout);
@@ -254,8 +252,7 @@ static void event_loop(LibcameraStillApp &app)
 		else if (app.StillStream())
 		{
 			app.StopCamera();
-			if (options->verbose >= 1)
-				std::cerr << "Still capture image received" << std::endl;
+			LOG(1, "Still capture image received");
 			save_images(app, std::get<CompletedRequestPtr>(msg.payload));
 			if (!options->metadata.empty())
 				save_metadata(options->metadata, std::get<CompletedRequestPtr>(msg.payload)->metadata);
@@ -288,7 +285,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -65,7 +65,7 @@ static void update_latest_link(std::string const &filename, StillOptions const *
 		{
 			if (symlink(filename.c_str(), options->latest.c_str()))
 				std::cerr << "WARNING: failed to create latest link " << options->latest << std::endl;
-			else if (options->verbose)
+			else if (options->verbose >= 2)
 				std::cerr << "Link " << options->latest << " created" << std::endl;
 		}
 	}
@@ -87,7 +87,7 @@ static void save_image(LibcameraStillApp &app, CompletedRequestPtr &payload, Str
 		bmp_save(mem, info, filename, options);
 	else
 		yuv_save(mem, info, filename, options);
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Saved image " << info.width << " x " << info.height << " to file " << filename << std::endl;
 }
 
@@ -217,7 +217,7 @@ static void event_loop(LibcameraStillApp &app)
 		// capture mode if an output was requested.
 		if (app.ViewfinderStream())
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Viewfinder frame " << count << std::endl;
 			timelapse_frames++;
 
@@ -254,7 +254,8 @@ static void event_loop(LibcameraStillApp &app)
 		else if (app.StillStream())
 		{
 			app.StopCamera();
-			std::cerr << "Still capture image received" << std::endl;
+			if (options->verbose >= 1)
+				std::cerr << "Still capture image received" << std::endl;
 			save_images(app, std::get<CompletedRequestPtr>(msg.payload));
 			if (!options->metadata.empty())
 				save_metadata(options->metadata, std::get<CompletedRequestPtr>(msg.payload)->metadata);
@@ -279,7 +280,7 @@ int main(int argc, char *argv[])
 		StillOptions *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 
 			event_loop(app);

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -22,7 +22,7 @@ static int signal_received;
 static void default_signal_handler(int signal_number)
 {
 	signal_received = signal_number;
-	std::cerr << "Received signal " << signal_number << std::endl;
+	LOG(1, "Received signal " << signal_number);
 }
 
 static int get_key_or_signal(VideoOptions const *options, pollfd p[1])
@@ -88,8 +88,7 @@ static void event_loop(LibcameraEncoder &app)
 		if (key == '\n')
 			output->Signal();
 
-		if (options->verbose >= 2)
-			std::cerr << "Viewfinder frame " << count << std::endl;
+		LOG(2, "Viewfinder frame " << count);
 		auto now = std::chrono::high_resolution_clock::now();
 		bool timeout = !options->frames && options->timeout &&
 					   (now - start_time > std::chrono::milliseconds(options->timeout));
@@ -97,7 +96,7 @@ static void event_loop(LibcameraEncoder &app)
 		if (timeout || frameout || key == 'x' || key == 'X')
 		{
 			if (timeout)
-				std::cerr << "Halting: reached timeout of " << options->timeout << " milliseconds.\n";
+				LOG(1, "Halting: reached timeout of " << options->timeout << " milliseconds.");
 			app.StopCamera(); // stop complains if encoder very slow to close
 			app.StopEncoder();
 			return;
@@ -125,7 +124,7 @@ int main(int argc, char *argv[])
 	}
 	catch (std::exception const &e)
 	{
-		std::cerr << "ERROR: *** " << e.what() << " ***" << std::endl;
+		LOG_ERROR("ERROR: *** " << e.what() << " ***");
 		return -1;
 	}
 	return 0;

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -88,7 +88,7 @@ static void event_loop(LibcameraEncoder &app)
 		if (key == '\n')
 			output->Signal();
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Viewfinder frame " << count << std::endl;
 		auto now = std::chrono::high_resolution_clock::now();
 		bool timeout = !options->frames && options->timeout &&
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
 		VideoOptions *options = app.GetOptions();
 		if (options->Parse(argc, argv))
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				options->Print();
 
 			event_loop(app);

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -66,6 +66,9 @@ LibcameraApp::LibcameraApp(std::unique_ptr<Options> opts)
 
 	if (!options_)
 		options_ = std::make_unique<Options>();
+
+	if (options_->verbose == 0)
+		libcamera::logSetTarget(libcamera::LoggingTargetNone);
 }
 
 LibcameraApp::~LibcameraApp()

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -68,9 +68,6 @@ LibcameraApp::LibcameraApp(std::unique_ptr<Options> opts)
 
 	if (!options_)
 		options_ = std::make_unique<Options>();
-
-	if (options_->verbose == 0)
-		libcamera::logSetTarget(libcamera::LoggingTargetNone);
 }
 
 LibcameraApp::~LibcameraApp()

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -17,6 +17,8 @@
 
 #include <linux/videodev2.h>
 
+unsigned int LibcameraApp::verbosity = 2;
+
 // If we definitely appear to be running the old camera stack, complain and give up.
 // Everything else, Pi or not, we let through.
 
@@ -73,10 +75,10 @@ LibcameraApp::LibcameraApp(std::unique_ptr<Options> opts)
 
 LibcameraApp::~LibcameraApp()
 {
-	if ((options_->verbose >= 2) && !options_->help)
-		std::cerr << "Closing Libcamera application"
-				  << "(frames displayed " << preview_frames_displayed_ << ", dropped " << preview_frames_dropped_ << ")"
-				  << std::endl;
+	if (!options_->help)
+		LOG(2, "Closing Libcamera application"
+				   << "(frames displayed " << preview_frames_displayed_ << ", dropped " << preview_frames_dropped_
+				   << ")");
 	StopCamera();
 	Teardown();
 	CloseCamera();
@@ -93,8 +95,7 @@ void LibcameraApp::OpenCamera()
 	preview_ = std::unique_ptr<Preview>(make_preview(options_.get()));
 	preview_->SetDoneCallback(std::bind(&LibcameraApp::previewDoneCallback, this, std::placeholders::_1));
 
-	if (options_->verbose >= 2)
-		std::cerr << "Opening camera..." << std::endl;
+	LOG(2, "Opening camera...");
 
 	camera_manager_ = std::make_unique<CameraManager>();
 	int ret = camera_manager_->start();
@@ -121,8 +122,7 @@ void LibcameraApp::OpenCamera()
 		throw std::runtime_error("failed to acquire camera " + cam_id);
 	camera_acquired_ = true;
 
-	if (options_->verbose >= 2)
-		std::cerr << "Acquired camera " << cam_id << std::endl;
+	LOG(2, "Acquired camera " << cam_id);
 
 	if (!options_->post_process_file.empty())
 		post_processor_.Read(options_->post_process_file);
@@ -143,14 +143,13 @@ void LibcameraApp::CloseCamera()
 
 	camera_manager_.reset();
 
-	if ((options_->verbose >= 2) && !options_->help)
-		std::cerr << "Camera closed" << std::endl;
+	if (!options_->help)
+		LOG(2, "Camera closed");
 }
 
 void LibcameraApp::ConfigureViewfinder()
 {
-	if (options_->verbose >= 2)
-		std::cerr << "Configuring viewfinder..." << std::endl;
+	LOG(2, "Configuring viewfinder...");
 
 	int lores_stream_num = 0, raw_stream_num = 0;
 	bool have_lores_stream = options_->lores_width && options_->lores_height;
@@ -181,8 +180,7 @@ void LibcameraApp::ConfigureViewfinder()
 		if (options_->width && options_->height)
 			size = size.boundedToAspectRatio(Size(options_->width, options_->height));
 		size.alignDownTo(2, 2); // YUV420 will want to be even
-		if (options_->verbose >= 2)
-			std::cerr << "Viewfinder size chosen is " << size.toString() << std::endl;
+		LOG(2, "Viewfinder size chosen is " << size.toString());
 	}
 
 	// Finally trim the image size to the largest that the preview can handle.
@@ -191,8 +189,7 @@ void LibcameraApp::ConfigureViewfinder()
 	if (max_size.width && max_size.height)
 	{
 		size.boundTo(max_size.boundedToAspectRatio(size)).alignDownTo(2, 2);
-		if (options_->verbose >= 2)
-			std::cerr << "Final viewfinder size is " << size.toString() << std::endl;
+		LOG(2, "Final viewfinder size is " << size.toString());
 	}
 
 	// Now we get to override any of the default settings from the options_->
@@ -232,14 +229,12 @@ void LibcameraApp::ConfigureViewfinder()
 
 	post_processor_.Configure();
 
-	if (options_->verbose >= 2)
-		std::cerr << "Viewfinder setup complete" << std::endl;
+	LOG(2, "Viewfinder setup complete");
 }
 
 void LibcameraApp::ConfigureStill(unsigned int flags)
 {
-	if (options_->verbose >= 2)
-		std::cerr << "Configuring still capture..." << std::endl;
+	LOG(2, "Configuring still capture...");
 
 	// Always request a raw stream as this forces the full resolution capture mode.
 	// (options_->mode can override the choice of camera mode, however.)
@@ -283,14 +278,12 @@ void LibcameraApp::ConfigureStill(unsigned int flags)
 
 	post_processor_.Configure();
 
-	if (options_->verbose >= 2)
-		std::cerr << "Still capture setup complete" << std::endl;
+	LOG(2, "Still capture setup complete");
 }
 
 void LibcameraApp::ConfigureVideo(unsigned int flags)
 {
-	if (options_->verbose >= 2)
-		std::cerr << "Configuring video..." << std::endl;
+	LOG(2, "Configuring video...");
 
 	bool have_raw_stream = (flags & FLAG_VIDEO_RAW) || options_->mode.bit_depth;
 	bool have_lores_stream = options_->lores_width && options_->lores_height;
@@ -360,8 +353,7 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 
 	post_processor_.Configure();
 
-	if (options_->verbose >= 2)
-		std::cerr << "Video setup complete" << std::endl;
+	LOG(2, "Video setup complete");
 }
 
 void LibcameraApp::Teardown()
@@ -370,8 +362,8 @@ void LibcameraApp::Teardown()
 
 	post_processor_.Teardown();
 
-	if ((options_->verbose >= 2) && !options_->help)
-		std::cerr << "Tearing down requests, buffers and configuration" << std::endl;
+	if (!options_->help)
+		LOG(2, "Tearing down requests, buffers and configuration");
 
 	for (auto &iter : mapped_buffers_)
 	{
@@ -408,8 +400,7 @@ void LibcameraApp::StartCamera()
 		int h = options_->roi_height * sensor_area.height;
 		Rectangle crop(x, y, w, h);
 		crop.translateBy(sensor_area.topLeft());
-		if (options_->verbose >= 2)
-			std::cerr << "Using crop " << crop.toString() << std::endl;
+		LOG(2, "Using crop " << crop.toString());
 		controls_.set(controls::ScalerCrop, crop);
 	}
 
@@ -466,8 +457,7 @@ void LibcameraApp::StartCamera()
 			throw std::runtime_error("Failed to queue request");
 	}
 
-	if (options_->verbose >= 2)
-		std::cerr << "Camera started!" << std::endl;
+	LOG(2, "Camera started!");
 }
 
 void LibcameraApp::StopCamera()
@@ -499,8 +489,8 @@ void LibcameraApp::StopCamera()
 
 	controls_.clear(); // no need for mutex here
 
-	if ((options_->verbose >= 2) && !options_->help)
-		std::cerr << "Camera stopped!" << std::endl;
+	if (!options_->help)
+		LOG(2, "Camera stopped!");
 }
 
 LibcameraApp::Msg LibcameraApp::Wait()
@@ -642,19 +632,15 @@ void LibcameraApp::setupCapture()
 	if (validation == CameraConfiguration::Invalid)
 		throw std::runtime_error("failed to valid stream configurations");
 	else if (validation == CameraConfiguration::Adjusted)
-		std::cerr << "Stream configuration adjusted" << std::endl;
+		LOG(1, "Stream configuration adjusted");
 
 	if (camera_->configure(configuration_.get()) < 0)
 		throw std::runtime_error("failed to configure streams");
-	if (options_->verbose >= 2)
-		std::cerr << "Camera streams configured" << std::endl;
+	LOG(2, "Camera streams configured");
 
-	if (options_->verbose >= 2)
-	{
-		std::cerr << "Available controls:" << std::endl;
-		for (auto const &[id, info] : camera_->controls())
-			std::cerr << "    " << id->name() << " : " << info.toString() << std::endl;
-	}
+	LOG(2, "Available controls:");
+	for (auto const &[id, info] : camera_->controls())
+		LOG(2, "    " << id->name() << " : " << info.toString());
 
 	// Next allocate all the buffers we need, mmap them and store them on a free list.
 
@@ -686,8 +672,7 @@ void LibcameraApp::setupCapture()
 			frame_buffers_[stream].push(buffer.get());
 		}
 	}
-	if (options_->verbose >= 2)
-		std::cerr << "Buffers allocated and mapped" << std::endl;
+	LOG(2, "Buffers allocated and mapped");
 
 	startPreview();
 
@@ -706,8 +691,7 @@ void LibcameraApp::makeRequests()
 			{
 				if (free_buffers[stream].empty())
 				{
-					if (options_->verbose >= 2)
-						std::cerr << "Requests created" << std::endl;
+					LOG(2, "Requests created");
 					return;
 				}
 				std::unique_ptr<Request> request = camera_->createRequest();
@@ -821,8 +805,7 @@ void LibcameraApp::previewThread()
 		}
 		if (preview_->Quit())
 		{
-			if (options_->verbose >= 2)
-				std::cerr << "Preview window has quit" << std::endl;
+			LOG(2, "Preview window has quit");
 			msg_queue_.Post(Msg(MsgType::Quit));
 		}
 		preview_frames_displayed_++;

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -122,6 +122,9 @@ public:
 	void SetControls(ControlList &controls);
 	StreamInfo GetStreamInfo(Stream const *stream) const;
 
+	static unsigned int verbosity;
+	static unsigned int GetVerbosity() { return verbosity; }
+
 protected:
 	std::unique_ptr<Options> options_;
 

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -26,6 +26,7 @@
 #include <libcamera/controls.h>
 #include <libcamera/formats.h>
 #include <libcamera/framebuffer_allocator.h>
+#include <libcamera/logging.h>
 #include <libcamera/property_ids.h>
 
 #include "core/completed_request.hpp"

--- a/core/logging.hpp
+++ b/core/logging.hpp
@@ -1,0 +1,9 @@
+#include "core/libcamera_app.hpp"
+
+#define LOG(level, text)                                                                                               \
+	do                                                                                                                 \
+	{                                                                                                                  \
+		if (LibcameraApp::GetVerbosity() >= level)                                                                     \
+			std::cerr << text << std::endl;                                                                            \
+	} while (0)
+#define LOG_ERROR(text) std::cerr << text << std::endl

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -66,6 +66,9 @@ bool Options::Parse(int argc, char *argv[])
 	// Set the verbosity
 	LibcameraApp::verbosity = verbose;
 
+	if (verbose == 0)
+		libcamera::logSetTarget(libcamera::LoggingTargetNone);
+
 	if (help)
 	{
 		std::cerr << options_;

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -63,6 +63,9 @@ bool Options::Parse(int argc, char *argv[])
 		notify(vm);
 	}
 
+	// Set the verbosity
+	LibcameraApp::verbosity = verbose;
+
 	if (help)
 	{
 		std::cerr << options_;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -48,8 +48,8 @@ struct Options
 			 "Lists the available cameras attached to the system.")
 			("camera", value<unsigned int>(&camera)->default_value(0),
 			 "Chooses the camera to use. To list the available indexes, use the --list-cameras option.")
-			("verbose,v", value<bool>(&verbose)->default_value(false)->implicit_value(true),
-			 "Output extra debug and diagnostics")
+			("verbose,v", value<unsigned int>(&verbose)->default_value(1)->implicit_value(2),
+			 "Set verbosity level. Level 0 is no output, 1 is default, 2 is verbose.")
 			("config,c", value<std::string>(&config_file)->implicit_value("config.txt"),
 			 "Read the options from a file. If no filename is specified, default to config.txt. "
 			 "In case of duplicate options, the ones provided on the command line will be used. "
@@ -138,7 +138,7 @@ struct Options
 	bool help;
 	bool version;
 	bool list_cameras;
-	bool verbose;
+	unsigned int verbose;
 	uint64_t timeout; // in ms
 	std::string config_file;
 	std::string output;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -18,6 +18,7 @@
 #include <libcamera/property_ids.h>
 #include <libcamera/transform.h>
 
+#include "core/logging.hpp"
 #include "core/version.hpp"
 
 struct Mode

--- a/core/post_processor.cpp
+++ b/core/post_processor.cpp
@@ -32,12 +32,12 @@ void PostProcessor::Read(std::string const &filename)
 		PostProcessingStage *stage = createPostProcessingStage(key_and_value.first.c_str());
 		if (stage)
 		{
-			std::cerr << "Reading post processing stage \"" << key_and_value.first << "\"" << std::endl;
+			LOG(1, "Reading post processing stage \"" << key_and_value.first << "\"");
 			stage->Read(key_and_value.second);
 			stages_.push_back(StagePtr(stage));
 		}
 		else
-			std::cerr << "No post processing stage found for \"" << key_and_value.first << "\"" << std::endl;
+			LOG(1, "No post processing stage found for \"" << key_and_value.first << "\"");
 	}
 }
 

--- a/core/post_processor.hpp
+++ b/core/post_processor.hpp
@@ -14,6 +14,7 @@
 #include <queue>
 
 #include "core/completed_request.hpp"
+#include "core/logging.hpp"
 
 namespace libcamera
 {

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -131,9 +131,9 @@ struct VideoOptions : public Options
 		else
 			throw std::runtime_error("incorrect initial value " + initial);
 		if ((pause || split || segment || circular) && !inline_headers)
-			std::cerr << "WARNING: consider inline headers with 'pause'/split/segment/circular" << std::endl;
+			LOG_ERROR("WARNING: consider inline headers with 'pause'/split/segment/circular");
 		if ((split || segment) && output.find('%') == std::string::npos)
-			std::cerr << "WARNING: expected % directive in output filename" << std::endl;
+			LOG_ERROR("WARNING: expected % directive in output filename");
 
 		return true;
 	}

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -47,7 +47,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	fd_ = open(device_name, O_RDWR, 0);
 	if (fd_ < 0)
 		throw std::runtime_error("failed to open V4L2 H264 encoder");
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Opened H264Encoder on " << device_name << " as fd " << fd_ << std::endl;
 
 	// Apply any options->
@@ -143,7 +143,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	reqbufs.memory = V4L2_MEMORY_DMABUF;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
 		throw std::runtime_error("request for output buffers failed");
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Got " << reqbufs.count << " output buffers" << std::endl;
 
 	// We have to maintain a list of the buffers we can use when our caller gives
@@ -157,7 +157,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	reqbufs.memory = V4L2_MEMORY_MMAP;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
 		throw std::runtime_error("request for capture buffers failed");
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Got " << reqbufs.count << " capture buffers" << std::endl;
 	num_capture_buffers_ = reqbufs.count;
 
@@ -191,7 +191,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
 	if (xioctl(fd_, VIDIOC_STREAMON, &type) < 0)
 		throw std::runtime_error("failed to start capture streaming");
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Codec streaming started" << std::endl;
 
 	output_thread_ = std::thread(&H264Encoder::outputThread, this);
@@ -233,7 +233,7 @@ H264Encoder::~H264Encoder()
 		std::cerr << "Request to free capture buffers failed" << std::endl;
 
 	close(fd_);
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "H264Encoder closed" << std::endl;
 }
 

--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -34,7 +34,7 @@ static int get_v4l2_colorspace(std::optional<libcamera::ColorSpace> const &cs)
 	else if (cs == libcamera::ColorSpace::Smpte170m)
 		return V4L2_COLORSPACE_SMPTE170M;
 
-	std::cerr << "H264: surprising colour space: " << libcamera::ColorSpace::toString(cs) << std::endl;
+	LOG(1, "H264: surprising colour space: " << libcamera::ColorSpace::toString(cs));
 	return V4L2_COLORSPACE_SMPTE170M;
 }
 
@@ -47,8 +47,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	fd_ = open(device_name, O_RDWR, 0);
 	if (fd_ < 0)
 		throw std::runtime_error("failed to open V4L2 H264 encoder");
-	if (options->verbose >= 2)
-		std::cerr << "Opened H264Encoder on " << device_name << " as fd " << fd_ << std::endl;
+	LOG(2, "Opened H264Encoder on " << device_name << " as fd " << fd_);
 
 	// Apply any options->
 
@@ -143,8 +142,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	reqbufs.memory = V4L2_MEMORY_DMABUF;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
 		throw std::runtime_error("request for output buffers failed");
-	if (options->verbose >= 2)
-		std::cerr << "Got " << reqbufs.count << " output buffers" << std::endl;
+	LOG(2, "Got " << reqbufs.count << " output buffers");
 
 	// We have to maintain a list of the buffers we can use when our caller gives
 	// us another frame to encode.
@@ -157,8 +155,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	reqbufs.memory = V4L2_MEMORY_MMAP;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
 		throw std::runtime_error("request for capture buffers failed");
-	if (options->verbose >= 2)
-		std::cerr << "Got " << reqbufs.count << " capture buffers" << std::endl;
+	LOG(2, "Got " << reqbufs.count << " capture buffers");
 	num_capture_buffers_ = reqbufs.count;
 
 	for (unsigned int i = 0; i < reqbufs.count; i++)
@@ -191,8 +188,7 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
 	if (xioctl(fd_, VIDIOC_STREAMON, &type) < 0)
 		throw std::runtime_error("failed to start capture streaming");
-	if (options->verbose >= 2)
-		std::cerr << "Codec streaming started" << std::endl;
+	LOG(2, "Codec streaming started");
 
 	output_thread_ = std::thread(&H264Encoder::outputThread, this);
 	poll_thread_ = std::thread(&H264Encoder::pollThread, this);
@@ -210,31 +206,30 @@ H264Encoder::~H264Encoder()
 
 	v4l2_buf_type type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
 	if (xioctl(fd_, VIDIOC_STREAMOFF, &type) < 0)
-		std::cerr << "Failed to stop output streaming" << std::endl;
+		LOG(1, "Failed to stop output streaming");
 	type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
 	if (xioctl(fd_, VIDIOC_STREAMOFF, &type) < 0)
-		std::cerr << "Failed to stop capture streaming" << std::endl;
+		LOG(1, "Failed to stop capture streaming");
 
 	v4l2_requestbuffers reqbufs = {};
 	reqbufs.count = 0;
 	reqbufs.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
 	reqbufs.memory = V4L2_MEMORY_DMABUF;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
-		std::cerr << "Request to free output buffers failed" << std::endl;
+		LOG(1, "Request to free output buffers failed");
 
 	for (int i = 0; i < num_capture_buffers_; i++)
 		if (munmap(buffers_[i].mem, buffers_[i].size) < 0)
-			std::cerr << "Failed to unmap buffer" << std::endl;
+			LOG(1, "Failed to unmap buffer");
 	reqbufs = {};
 	reqbufs.count = 0;
 	reqbufs.type = V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE;
 	reqbufs.memory = V4L2_MEMORY_MMAP;
 	if (xioctl(fd_, VIDIOC_REQBUFS, &reqbufs) < 0)
-		std::cerr << "Request to free capture buffers failed" << std::endl;
+		LOG(1, "Request to free capture buffers failed");
 
 	close(fd_);
-	if (options_->verbose >= 2)
-		std::cerr << "H264Encoder closed" << std::endl;
+	LOG(2, "H264Encoder closed");
 }
 
 void H264Encoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -215,8 +215,7 @@ LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
 
 	av_dump_format(out_fmt_ctx_, 0, options_->output.c_str(), 1);
 
-	if (options->verbose >= 2)
-		std::cerr << "libav: codec init completed" << std::endl;
+	LOG(2, "libav: codec init completed");
 
 	video_thread_ = std::thread(&LibAvEncoder::videoThread, this);
 
@@ -245,8 +244,7 @@ LibAvEncoder::~LibAvEncoder()
 		avcodec_free_context(&codec_ctx_[AudioOut]);
 	}
 
-	if (options_->verbose >= 2)
-		std::cerr << "libav: codec closed" << std::endl;
+	LOG(2, "libav: codec closed");
 }
 
 void LibAvEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
@@ -486,7 +484,7 @@ void LibAvEncoder::audioThread()
 
 		if (av_audio_fifo_space(fifo) < in_frame->nb_samples)
 		{
-			std::cerr << "libav: Draining audio fifo, configure a larger size" << std::endl;
+			LOG(1, "libav: Draining audio fifo, configure a larger size");
 			av_audio_fifo_drain(fifo, in_frame->nb_samples);
 		}
 

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -202,7 +202,7 @@ LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
 {
 	avdevice_register_all();
 
-	if (options->verbose)
+	if (options->verbose >= 2)
 		av_log_set_level(AV_LOG_VERBOSE);
 
 	initVideoCodec(options, info);
@@ -215,7 +215,7 @@ LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
 
 	av_dump_format(out_fmt_ctx_, 0, options_->output.c_str(), 1);
 
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "libav: codec init completed" << std::endl;
 
 	video_thread_ = std::thread(&LibAvEncoder::videoThread, this);
@@ -245,7 +245,7 @@ LibAvEncoder::~LibAvEncoder()
 		avcodec_free_context(&codec_ctx_[AudioOut]);
 	}
 
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "libav: codec closed" << std::endl;
 }
 

--- a/encoder/mjpeg_encoder.cpp
+++ b/encoder/mjpeg_encoder.cpp
@@ -24,8 +24,7 @@ MjpegEncoder::MjpegEncoder(VideoOptions const *options)
 	output_thread_ = std::thread(&MjpegEncoder::outputThread, this);
 	for (int i = 0; i < NUM_ENC_THREADS; i++)
 		encode_thread_[i] = std::thread(std::bind(&MjpegEncoder::encodeThread, this, i));
-	if (options_->verbose >= 2)
-		std::cerr << "Opened MjpegEncoder" << std::endl;
+	LOG(2, "Opened MjpegEncoder");
 }
 
 MjpegEncoder::~MjpegEncoder()
@@ -35,8 +34,7 @@ MjpegEncoder::~MjpegEncoder()
 		encode_thread_[i].join();
 	abortOutput_ = true;
 	output_thread_.join();
-	if (options_->verbose >= 2)
-		std::cerr << "MjpegEncoder closed" << std::endl;
+	LOG(2, "MjpegEncoder closed");
 }
 
 void MjpegEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
@@ -112,9 +110,9 @@ void MjpegEncoder::encodeThread(int num)
 				using namespace std::chrono_literals;
 				if (abortEncode_ && encode_queue_.empty())
 				{
-					if (frames && (options_->verbose) >= 2)
-						std::cerr << "Encode " << frames << " frames, average time "
-								  << encode_time.count() * 1000 / frames << "ms" << std::endl;
+					if (frames)
+						LOG(2, "Encode " << frames << " frames, average time " << encode_time.count() * 1000 / frames
+										 << "ms");
 					jpeg_destroy_compress(&cinfo);
 					return;
 				}

--- a/encoder/mjpeg_encoder.cpp
+++ b/encoder/mjpeg_encoder.cpp
@@ -24,7 +24,7 @@ MjpegEncoder::MjpegEncoder(VideoOptions const *options)
 	output_thread_ = std::thread(&MjpegEncoder::outputThread, this);
 	for (int i = 0; i < NUM_ENC_THREADS; i++)
 		encode_thread_[i] = std::thread(std::bind(&MjpegEncoder::encodeThread, this, i));
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "Opened MjpegEncoder" << std::endl;
 }
 
@@ -35,7 +35,7 @@ MjpegEncoder::~MjpegEncoder()
 		encode_thread_[i].join();
 	abortOutput_ = true;
 	output_thread_.join();
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "MjpegEncoder closed" << std::endl;
 }
 
@@ -112,7 +112,7 @@ void MjpegEncoder::encodeThread(int num)
 				using namespace std::chrono_literals;
 				if (abortEncode_ && encode_queue_.empty())
 				{
-					if (frames && options_->verbose)
+					if (frames && (options_->verbose) >= 2)
 						std::cerr << "Encode " << frames << " frames, average time "
 								  << encode_time.count() * 1000 / frames << "ms" << std::endl;
 					jpeg_destroy_compress(&cinfo);

--- a/encoder/null_encoder.cpp
+++ b/encoder/null_encoder.cpp
@@ -13,7 +13,7 @@
 
 NullEncoder::NullEncoder(VideoOptions const *options) : Encoder(options), abort_(false)
 {
-	if (options->verbose)
+	if (options->verbose >= 2)
 		std::cerr << "Opened NullEncoder" << std::endl;
 	output_thread_ = std::thread(&NullEncoder::outputThread, this);
 }

--- a/encoder/null_encoder.cpp
+++ b/encoder/null_encoder.cpp
@@ -13,8 +13,7 @@
 
 NullEncoder::NullEncoder(VideoOptions const *options) : Encoder(options), abort_(false)
 {
-	if (options->verbose >= 2)
-		std::cerr << "Opened NullEncoder" << std::endl;
+	LOG(2, "Opened NullEncoder");
 	output_thread_ = std::thread(&NullEncoder::outputThread, this);
 }
 
@@ -22,8 +21,7 @@ NullEncoder::~NullEncoder()
 {
 	abort_ = true;
 	output_thread_.join();
-	if (options_.verbose)
-		std::cerr << "NullEncoder closed" << std::endl;
+	LOG(2, "NullEncoder closed");
 }
 
 // Push the buffer onto the output queue to be "encoded" and returned.

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -77,7 +77,7 @@ void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 				throw std::runtime_error("failed to write BMP file, row " + std::to_string(i));
 		}
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Wrote " << file_header.filesize << " bytes to BMP file" << std::endl;
 
 		if (fp != stdout)

--- a/image/bmp.cpp
+++ b/image/bmp.cpp
@@ -77,8 +77,7 @@ void bmp_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 				throw std::runtime_error("failed to write BMP file, row " + std::to_string(i));
 		}
 
-		if (options->verbose >= 2)
-			std::cerr << "Wrote " << file_header.filesize << " bytes to BMP file" << std::endl;
+		LOG(2, "Wrote " << file_header.filesize << " bytes to BMP file");
 
 		if (fp != stdout)
 			fclose(fp);

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -205,7 +205,7 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 				   0.0193339, 0.1191920, 0.9503041);
 	Matrix CAM_XYZ = (RGB2XYZ * CCM * WB_GAINS).Inv();
 
-	if (options->verbose)
+	if (options->verbose >= 2)
 	{
 		std::cerr << "Black levels " << black_levels[0] << " " << black_levels[1] << " " << black_levels[2] << " "
 				  << black_levels[3] << ", exposure time " << exp_time * 1e6 << "us, ISO " << iso << std::endl;

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -136,7 +136,7 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 	if (it == bayer_formats.end())
 		throw std::runtime_error("unsupported Bayer format");
 	BayerFormat const &bayer_format = it->second;
-	std::cerr << "Bayer format is " << bayer_format.name << "\n";
+	LOG(1, "Bayer format is " << bayer_format.name);
 
 	std::vector<uint16_t> buf(info.width * info.height);
 	if (bayer_format.bits == 10)
@@ -162,20 +162,20 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		}
 	}
 	else
-		std::cerr << "WARNING: no black level found, using default" << std::endl;
+		LOG_ERROR("WARNING: no black level found, using default");
 
 	float exp_time = 10000;
 	if (metadata.contains(controls::ExposureTime))
 		exp_time = metadata.get(controls::ExposureTime);
 	else
-		std::cerr << "WARNING: default to exposure time of " << exp_time << "us" << std::endl;
+		LOG_ERROR("WARNING: default to exposure time of " << exp_time << "us");
 	exp_time /= 1e6;
 
 	uint16_t iso = 100;
 	if (metadata.contains(controls::AnalogueGain))
 		iso = metadata.get(controls::AnalogueGain) * 100.0;
 	else
-		std::cerr << "WARNING: default to ISO value of " << iso << std::endl;
+		LOG_ERROR("WARNING: default to ISO value of " << iso);
 
 	float NEUTRAL[] = { 1, 1, 1 };
 	Matrix WB_GAINS(1, 1, 1);
@@ -197,7 +197,7 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		CCM = Matrix(coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5], coeffs[6], coeffs[7], coeffs[8]);
 	}
 	else
-		std::cerr << "WARNING: no CCM metadata found" << std::endl;
+		LOG_ERROR("WARNING: no CCM metadata found");
 
 	// This maxtrix from http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
 	Matrix RGB2XYZ(0.4124564, 0.3575761, 0.1804375,
@@ -205,16 +205,13 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 				   0.0193339, 0.1191920, 0.9503041);
 	Matrix CAM_XYZ = (RGB2XYZ * CCM * WB_GAINS).Inv();
 
-	if (options->verbose >= 2)
-	{
-		std::cerr << "Black levels " << black_levels[0] << " " << black_levels[1] << " " << black_levels[2] << " "
-				  << black_levels[3] << ", exposure time " << exp_time * 1e6 << "us, ISO " << iso << std::endl;
-		std::cerr << "Neutral " << NEUTRAL[0] << " " << NEUTRAL[1] << " " << NEUTRAL[2] << std::endl;
-		std::cerr << "Cam_XYZ: " << std::endl;
-		std::cerr << CAM_XYZ.m[0] << " " << CAM_XYZ.m[1] << " " << CAM_XYZ.m[2] << std::endl;
-		std::cerr << CAM_XYZ.m[3] << " " << CAM_XYZ.m[4] << " " << CAM_XYZ.m[5] << std::endl;
-		std::cerr << CAM_XYZ.m[6] << " " << CAM_XYZ.m[7] << " " << CAM_XYZ.m[8] << std::endl;
-	}
+	LOG(2, "Black levels " << black_levels[0] << " " << black_levels[1] << " " << black_levels[2] << " "
+						   << black_levels[3] << ", exposure time " << exp_time * 1e6 << "us, ISO " << iso);
+	LOG(2, "Neutral " << NEUTRAL[0] << " " << NEUTRAL[1] << " " << NEUTRAL[2]);
+	LOG(2, "Cam_XYZ: ");
+	LOG(2, CAM_XYZ.m[0] << " " << CAM_XYZ.m[1] << " " << CAM_XYZ.m[2]);
+	LOG(2, CAM_XYZ.m[3] << " " << CAM_XYZ.m[4] << " " << CAM_XYZ.m[5]);
+	LOG(2, CAM_XYZ.m[6] << " " << CAM_XYZ.m[7] << " " << CAM_XYZ.m[8]);
 
 	// Finally write the DNG.
 

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -475,7 +475,7 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 		{
 			entry = exif_create_tag(exif, EXIF_IFD_EXIF, EXIF_TAG_EXPOSURE_TIME);
 			int32_t exposure_time = metadata.get(libcamera::controls::ExposureTime);
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Exposure time: " << exposure_time << std::endl;
 			ExifRational exposure = { (ExifLong)exposure_time, 1000000 };
 			exif_set_rational(entry->data, exif_byte_order, exposure);
@@ -487,7 +487,7 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 			if (metadata.contains(libcamera::controls::DigitalGain))
 				dg = metadata.get(libcamera::controls::DigitalGain);
 			gain = ag * dg;
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Ag " << ag << " Dg " << dg << " Total " << gain << std::endl;
 			exif_set_short(entry->data, exif_byte_order, 100 * gain);
 		}
@@ -495,7 +495,7 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 		// Command-line supplied tags.
 		for (auto &exif_item : options->exif)
 		{
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Processing EXIF item: " << exif_item << std::endl;
 			exif_read_tag(exif, exif_item.c_str());
 		}
@@ -505,7 +505,7 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 			// Add some tags for the thumbnail. We put in dummy values for the thumbnail
 			// offset/length to occupy the right amount of space, and fill them in later.
 
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Thumbnail dimensions are " << options->thumb_width << " x " << options->thumb_height
 						  << std::endl;
 			entry = exif_create_tag(exif, EXIF_IFD_1, EXIF_TAG_IMAGE_WIDTH);
@@ -539,7 +539,7 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 				free(thumb_buffer);
 				thumb_buffer = nullptr;
 			}
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Thumbnail size " << thumb_len << std::endl;
 			if (q <= 0)
 				throw std::runtime_error("failed to make acceptable thumbnail");
@@ -598,7 +598,7 @@ void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo cons
 		jpeg_mem_len_t jpeg_len;
 		YUV_to_JPEG((uint8_t *)(mem[0].data()), info, info.width, info.height, options->quality,
 					options->restart, jpeg_buffer, jpeg_len);
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "JPEG size is " << jpeg_len << std::endl;
 
 		// Write everything out.
@@ -607,7 +607,7 @@ void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo cons
 		if (!fp)
 			throw std::runtime_error("failed to open file " + options->output);
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "EXIF data len " << exif_len << std::endl;
 
 		if (fwrite(exif_header, sizeof(exif_header), 1, fp) != 1 || fputc((exif_len + thumb_len + 2) >> 8, fp) == EOF ||

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -59,7 +59,7 @@ void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		png_set_rows(png_ptr, info_ptr, row_ptrs);
 		png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
 
-		if (options->verbose)
+		if (options->verbose >= 2)
 		{
 			long int size = ftell(fp);
 			std::cerr << "Wrote PNG file of " << size << " bytes" << std::endl;

--- a/image/png.cpp
+++ b/image/png.cpp
@@ -59,11 +59,8 @@ void png_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		png_set_rows(png_ptr, info_ptr, row_ptrs);
 		png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
 
-		if (options->verbose >= 2)
-		{
-			long int size = ftell(fp);
-			std::cerr << "Wrote PNG file of " << size << " bytes" << std::endl;
-		}
+		long int size = ftell(fp);
+		LOG(2, "Wrote PNG file of " << size << " bytes");
 
 		// Free and close everything and we're done.
 		png_free(png_ptr, row_ptrs);

--- a/output/circular_output.cpp
+++ b/output/circular_output.cpp
@@ -65,7 +65,7 @@ CircularOutput::~CircularOutput()
 			cb_.Skip((header.length + ALIGN - 1) & ~(ALIGN - 1));
 	}
 	fclose(fp_);
-	std::cerr << "Wrote " << total << " bytes (" << frames << " frames)" << std::endl;
+	LOG(1, "Wrote " << total << " bytes (" << frames << " frames)");
 }
 
 void CircularOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t flags)

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -31,8 +31,7 @@ void FileOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint
 		openFile(timestamp_us);
 	}
 
-	if (options_->verbose >= 2)
-		std::cerr << "FileOutput: output buffer " << mem << " size " << size << "\n";
+	LOG(2, "FileOutput: output buffer " << mem << " size " << size);
 	if (fp_ && size)
 	{
 		if (fwrite(mem, size, 1, fp_) != 1)
@@ -60,8 +59,7 @@ void FileOutput::openFile(int64_t timestamp_us)
 		fp_ = fopen(filename, "w");
 		if (!fp_)
 			throw std::runtime_error("failed to open output file " + std::string(filename));
-		if (options_->verbose >= 2)
-			std::cerr << "FileOutput: opened output file " << filename << std::endl;
+		LOG(2, "FileOutput: opened output file " << filename);
 
 		file_start_time_ms_ = timestamp_us / 1000;
 	}

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -31,7 +31,7 @@ void FileOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint
 		openFile(timestamp_us);
 	}
 
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "FileOutput: output buffer " << mem << " size " << size << "\n";
 	if (fp_ && size)
 	{
@@ -60,7 +60,7 @@ void FileOutput::openFile(int64_t timestamp_us)
 		fp_ = fopen(filename, "w");
 		if (!fp_)
 			throw std::runtime_error("failed to open output file " + std::string(filename));
-		if (options_->verbose)
+		if (options_->verbose >= 2)
 			std::cerr << "FileOutput: opened output file " << filename << std::endl;
 
 		file_start_time_ms_ = timestamp_us / 1000;

--- a/output/net_output.cpp
+++ b/output/net_output.cpp
@@ -56,13 +56,11 @@ NetOutput::NetOutput(VideoOptions const *options) : Output(options)
 				throw std::runtime_error("failed to bind listen socket");
 			listen(listen_fd, 1);
 
-			if (options->verbose >= 2)
-				std::cerr << "Waiting for client to connect..." << std::endl;
+			LOG(2, "Waiting for client to connect...");
 			fd_ = accept(listen_fd, (struct sockaddr *)&saddr_, &sockaddr_in_size_);
 			if (fd_ < 0)
 				throw std::runtime_error("accept socket failed");
-			if (options->verbose >= 2)
-				std::cerr << "Client connection accepted" << std::endl;
+			LOG(2, "Client connection accepted");
 
 			close(listen_fd);
 		}
@@ -79,12 +77,10 @@ NetOutput::NetOutput(VideoOptions const *options) : Output(options)
 			if (fd_ < 0)
 				throw std::runtime_error("unable to open client socket");
 
-			if (options->verbose >= 2)
-				std::cerr << "Connecting to server..." << std::endl;
+			LOG(2, "Connecting to server...");
 			if (connect(fd_, (struct sockaddr *)&saddr_, sizeof(sockaddr_in)) < 0)
 				throw std::runtime_error("connect to server failed");
-			if (options->verbose >= 2)
-				std::cerr << "Connected" << std::endl;
+			LOG(2, "Connected");
 		}
 
 		saddr_ptr_ = NULL; // sendto doesn't want these for tcp
@@ -104,8 +100,7 @@ constexpr size_t MAX_UDP_SIZE = 65507;
 
 void NetOutput::outputBuffer(void *mem, size_t size, int64_t /*timestamp_us*/, uint32_t /*flags*/)
 {
-	if (options_->verbose >= 2)
-		std::cerr << "NetOutput: output buffer " << mem << " size " << size << "\n";
+	LOG(2, "NetOutput: output buffer " << mem << " size " << size);
 	size_t max_size = saddr_ptr_ ? MAX_UDP_SIZE : size;
 	for (uint8_t *ptr = (uint8_t *)mem; size;)
 	{

--- a/output/net_output.cpp
+++ b/output/net_output.cpp
@@ -56,12 +56,12 @@ NetOutput::NetOutput(VideoOptions const *options) : Output(options)
 				throw std::runtime_error("failed to bind listen socket");
 			listen(listen_fd, 1);
 
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Waiting for client to connect..." << std::endl;
 			fd_ = accept(listen_fd, (struct sockaddr *)&saddr_, &sockaddr_in_size_);
 			if (fd_ < 0)
 				throw std::runtime_error("accept socket failed");
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Client connection accepted" << std::endl;
 
 			close(listen_fd);
@@ -79,11 +79,11 @@ NetOutput::NetOutput(VideoOptions const *options) : Output(options)
 			if (fd_ < 0)
 				throw std::runtime_error("unable to open client socket");
 
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Connecting to server..." << std::endl;
 			if (connect(fd_, (struct sockaddr *)&saddr_, sizeof(sockaddr_in)) < 0)
 				throw std::runtime_error("connect to server failed");
-			if (options->verbose)
+			if (options->verbose >= 2)
 				std::cerr << "Connected" << std::endl;
 		}
 
@@ -104,7 +104,7 @@ constexpr size_t MAX_UDP_SIZE = 65507;
 
 void NetOutput::outputBuffer(void *mem, size_t size, int64_t /*timestamp_us*/, uint32_t /*flags*/)
 {
-	if (options_->verbose)
+	if (options_->verbose >= 2)
 		std::cerr << "NetOutput: output buffer " << mem << " size " << size << "\n";
 	size_t max_size = saddr_ptr_ ? MAX_UDP_SIZE : size;
 	for (uint8_t *ptr = (uint8_t *)mem; size;)

--- a/post_processing_stages/hdr_stage.cpp
+++ b/post_processing_stages/hdr_stage.cpp
@@ -479,7 +479,7 @@ bool HdrStage::Process(CompletedRequestPtr &completed_request)
 	uint8_t *image = buffer.data();
 
 	// Accumulate frame.
-	std::cerr << "Accumulating frame " << frame_num_ << std::endl;
+	LOG(1, "Accumulating frame " << frame_num_);
 	acc_.Accumulate(image, info_.stride);
 
 	// Optionally save individual JPEGs of each of the constituent images. Obviously this
@@ -493,7 +493,7 @@ bool HdrStage::Process(CompletedRequestPtr &completed_request)
 		if (options)
 			jpeg_save(buffers, info_, completed_request->metadata, filename, app_->CameraId(), options);
 		else
-			std::cerr << "No still options - unable to save JPEG" << std::endl;
+			LOG(1, "No still options - unable to save JPEG");
 	}
 
 	// Now we'll drop this frame unless it's the last one that we need, at which point
@@ -503,14 +503,14 @@ bool HdrStage::Process(CompletedRequestPtr &completed_request)
 		return true;
 
 	// Do HDR processing.
-	std::cerr << "Doing HDR processing..." << std::endl;
+	LOG(1, "Doing HDR processing...");
 	acc_.Scale(16.0 / config_.num_frames);
 
 	lp_ = acc_.LpFilter(config_.lp_filter);
 	acc_.Tonemap(lp_, config_);
 
 	acc_.Extract(image, info_.stride);
-	std::cerr << "HDR done!" << std::endl;
+	LOG(1, "HDR done!");
 
 	return false;
 }

--- a/post_processing_stages/motion_detect_stage.cpp
+++ b/post_processing_stages/motion_detect_stage.cpp
@@ -117,8 +117,8 @@ void MotionDetectStage::Configure()
 	region_threshold_ = std::clamp(region_threshold_, 0u, roi_width_ * roi_height_);
 
 	if (config_.verbose)
-		std::cerr << "Lores: " << info.width << "x" << info.height << " roi: (" << roi_x_ << "," << roi_y_ << ") "
-				  << roi_width_ << "x" << roi_height_ << " threshold: " << region_threshold_ << std::endl;
+		LOG(1, "Lores: " << info.width << "x" << info.height << " roi: (" << roi_x_ << "," << roi_y_ << ") "
+						 << roi_width_ << "x" << roi_height_ << " threshold: " << region_threshold_);
 
 	previous_frame_.resize(roi_width_ * roi_height_);
 	first_time_ = true;
@@ -175,7 +175,7 @@ bool MotionDetectStage::Process(CompletedRequestPtr &completed_request)
 	}
 
 	if (config_.verbose && motion_detected != motion_detected_)
-		std::cerr << "Motion " << (motion_detected ? "detected" : "stopped") << std::endl;
+		LOG(1, "Motion " << (motion_detected ? "detected" : "stopped"));
 
 	motion_detected_ = motion_detected;
 	completed_request->post_process_metadata.Set("motion_detect.result", motion_detected);

--- a/post_processing_stages/object_classify_tf_stage.cpp
+++ b/post_processing_stages/object_classify_tf_stage.cpp
@@ -134,8 +134,8 @@ void ObjectClassifyTfStage::interpretOutputs()
 	if (config_->verbose)
 	{
 		for (const auto &result : output_results_)
-			std::cerr << result.first << " : " << std::to_string(result.second) << std::endl;
-		std::cerr << std::endl;
+			LOG(1, result.first << " : " << std::to_string(result.second));
+		LOG(1, "");
 	}
 }
 

--- a/post_processing_stages/object_detect_tf_stage.cpp
+++ b/post_processing_stages/object_detect_tf_stage.cpp
@@ -62,7 +62,7 @@ void ObjectDetectTfStage::readExtras(boost::property_tree::ptree const &params)
 	std::string labels_file = params.get<std::string>("labels_file", "");
 	readLabelsFile(labels_file);
 	if (config()->verbose)
-		std::cerr << "Read " << label_count_ << " labels" << std::endl;
+		LOG(1, "Read " << label_count_ << " labels");
 
 	// Check the tensor outputs and label classes match up.
 	int output = interpreter_->outputs()[0];
@@ -165,7 +165,7 @@ void ObjectDetectTfStage::interpretOutputs()
 	if (config()->verbose)
 	{
 		for (auto &detection : output_results_)
-			std::cerr << detection.toString() << std::endl;
+			LOG(1, detection.toString());
 	}
 }
 

--- a/post_processing_stages/tf_stage.cpp
+++ b/post_processing_stages/tf_stage.cpp
@@ -31,7 +31,7 @@ void TfStage::initialise()
 	model_ = tflite::FlatBufferModel::BuildFromFile(config_->model_file.c_str());
 	if (!model_)
 		throw std::runtime_error("TfStage: Failed to load model");
-	std::cerr << "TfStage: Loaded model " << config_->model_file << std::endl;
+	LOG(1, "TfStage: Loaded model " << config_->model_file);
 
 	tflite::ops::builtin::BuiltinOpResolver resolver;
 	tflite::InterpreterBuilder(*model_, resolver)(&interpreter_);
@@ -67,27 +67,25 @@ void TfStage::Configure()
 	{
 		lores_info_ = app_->GetStreamInfo(lores_stream_);
 		if (config_->verbose)
-			std::cerr << "TfStage: Low resolution stream is " << lores_info_.width << "x"
-					  << lores_info_.height << std::endl;
+			LOG(1, "TfStage: Low resolution stream is " << lores_info_.width << "x" << lores_info_.height);
 		if (tf_w_ > lores_info_.width || tf_h_ > lores_info_.height)
 		{
-			std::cerr << "TfStage: WARNING: Low resolution image too small" << std::endl;
+			LOG_ERROR("TfStage: WARNING: Low resolution image too small");
 			lores_stream_ = nullptr;
 		}
 	}
 	else if (config_->verbose)
-		std::cerr << "TfStage: no low resolution stream" << std::endl;
+		LOG(1, "TfStage: no low resolution stream");
 
 	main_stream_ = app_->GetMainStream();
 	if (main_stream_)
 	{
 		main_stream_info_ = app_->GetStreamInfo(main_stream_);
 		if (config_->verbose)
-			std::cerr << "TfStage: Main stream is " << main_stream_info_.width << "x"
-					  << main_stream_info_.height << std::endl;
+			LOG(1, "TfStage: Main stream is " << main_stream_info_.width << "x" << main_stream_info_.height);
 	}
 	else if (config_->verbose)
-		std::cerr << "TfStage: No main stream" << std::endl;
+		LOG(1, "TfStage: No main stream");
 
 	checkConfiguration();
 }
@@ -114,7 +112,7 @@ bool TfStage::Process(CompletedRequestPtr &completed_request)
 				auto time_taken = ExecutionTime<std::micro>(&TfStage::runInference, this).count();
 
 				if (config_->verbose)
-					std::cerr << "TfStage: Inference time: " << time_taken << " ms" << std::endl;
+					LOG(1, "TfStage: Inference time: " << time_taken << " ms");
 			});
 		}
 	}

--- a/preview/drm_preview.cpp
+++ b/preview/drm_preview.cpp
@@ -82,8 +82,7 @@ void DrmPreview::findCrtc()
 
 	if (!conId_)
 	{
-		if (options_->verbose >= 2)
-			std::cerr << "No connector ID specified.  Choosing default from list:" << std::endl;
+		LOG(2, "No connector ID specified.  Choosing default from list:");
 
 		for (i = 0; i < res->count_connectors; i++)
 		{
@@ -112,10 +111,9 @@ void DrmPreview::findCrtc()
 				screen_height_ = crtc->height;
 			}
 
-			if (options_->verbose >= 2)
-				std::cerr << "Connector " << con->connector_id << " (crtc " << (crtc ? crtc->crtc_id : 0) << "): type "
-						  << con->connector_type << ", " << (crtc ? crtc->width : 0) << "x" << (crtc ? crtc->height : 0)
-						  << (conId_ == (int)con->connector_id ? " (chosen)" : "") << std::endl;
+			LOG(2, "Connector " << con->connector_id << " (crtc " << (crtc ? crtc->crtc_id : 0) << "): type "
+								<< con->connector_type << ", " << (crtc ? crtc->width : 0) << "x"
+								<< (crtc ? crtc->height : 0) << (conId_ == (int)con->connector_id ? " (chosen)" : ""));
 		}
 
 		if (!conId_)
@@ -288,7 +286,7 @@ static void get_colour_space_info(std::optional<libcamera::ColorSpace> const &cs
 	else if (cs == libcamera::ColorSpace::Rec709)
 		encoding = encoding_709;
 	else
-		std::cerr << "DrmPreview: unexpected colour space " << libcamera::ColorSpace::toString(cs) << std::endl;
+		LOG(1, "DrmPreview: unexpected colour space " << libcamera::ColorSpace::toString(cs));
 }
 
 static int drm_set_property(int fd, int plane_id, char const *name, char const *val)
@@ -321,15 +319,15 @@ static int drm_set_property(int fd, int plane_id, char const *name, char const *
 
 			ret = drmModeObjectSetProperty(fd, plane_id, DRM_MODE_OBJECT_PLANE, prop_id, prop->enums[j].value);
 			if (ret < 0)
-				std::cerr << "DrmPreview: failed to set value " << val << " for property " << name << std::endl;
+				LOG(1, "DrmPreview: failed to set value " << val << " for property " << name);
 			goto done;
 		}
 
-		std::cerr << "DrmPreview: failed to find value " << val << " for property " << name << std::endl;
+		LOG(1, "DrmPreview: failed to find value " << val << " for property " << name);
 		goto done;
 	}
 
-	std::cerr << "DrmPreview: failed to find property " << name << std::endl;
+	LOG(1, "DrmPreview: failed to find property " << name);
 done:
 	if (prop)
 		drmModeFreeProperty(prop);
@@ -404,7 +402,7 @@ void DrmPreview::Reset()
 		gem_close.handle = it.second.bo_handle;
 		if (drmIoctl(drmfd_, DRM_IOCTL_GEM_CLOSE, &gem_close) < 0)
 			// I have no idea what this would mean, so complain and try to carry on...
-			std::cerr << "DRM_IOCTL_GEM_CLOSE failed" << std::endl;
+			LOG(1, "DRM_IOCTL_GEM_CLOSE failed");
 	}
 	buffers_.clear();
 	last_fd_ = -1;

--- a/preview/drm_preview.cpp
+++ b/preview/drm_preview.cpp
@@ -82,7 +82,7 @@ void DrmPreview::findCrtc()
 
 	if (!conId_)
 	{
-		if (options_->verbose)
+		if (options_->verbose >= 2)
 			std::cerr << "No connector ID specified.  Choosing default from list:" << std::endl;
 
 		for (i = 0; i < res->count_connectors; i++)
@@ -112,7 +112,7 @@ void DrmPreview::findCrtc()
 				screen_height_ = crtc->height;
 			}
 
-			if (options_->verbose)
+			if (options_->verbose >= 2)
 				std::cerr << "Connector " << con->connector_id << " (crtc " << (crtc ? crtc->crtc_id : 0) << "): type "
 						  << con->connector_type << ", " << (crtc ? crtc->width : 0) << "x" << (crtc ? crtc->height : 0)
 						  << (conId_ == (int)con->connector_id ? " (chosen)" : "") << std::endl;

--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -352,7 +352,7 @@ static void get_colour_space_info(std::optional<libcamera::ColorSpace> const &cs
 	else if (cs == libcamera::ColorSpace::Rec709)
 		encoding = EGL_ITU_REC709_EXT;
 	else
-		std::cerr << "EglPreview: unexpected colour space " << libcamera::ColorSpace::toString(cs) << std::endl;
+		LOG(1, "EglPreview: unexpected colour space " << libcamera::ColorSpace::toString(cs));
 }
 
 void EglPreview::makeBuffer(int fd, size_t size, StreamInfo const &info, Buffer &buffer)

--- a/preview/null_preview.cpp
+++ b/preview/null_preview.cpp
@@ -14,18 +14,11 @@
 class NullPreview : public Preview
 {
 public:
-	NullPreview(Options const *options) : Preview(options)
-	{
-		if (options->verbose >= 2)
-			std::cerr << "Running without preview window" << std::endl;
-	}
+	NullPreview(Options const *options) : Preview(options) { LOG(2, "Running without preview window"); }
 	~NullPreview() {}
 	// Display the buffer. You get given the fd back in the BufferDoneCallback
 	// once its available for re-use.
-	virtual void Show(int fd, libcamera::Span<uint8_t> span, StreamInfo const &info) override
-	{
-		done_callback_(fd);
-	}
+	virtual void Show(int fd, libcamera::Span<uint8_t> span, StreamInfo const &info) override { done_callback_(fd); }
 	// Reset the preview window, clearing the current buffers and being ready to
 	// show new ones.
 	void Reset() override {}

--- a/preview/null_preview.cpp
+++ b/preview/null_preview.cpp
@@ -16,7 +16,7 @@ class NullPreview : public Preview
 public:
 	NullPreview(Options const *options) : Preview(options)
 	{
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Running without preview window" << std::endl;
 	}
 	~NullPreview() {}

--- a/preview/preview.cpp
+++ b/preview/preview.cpp
@@ -23,7 +23,7 @@ Preview *make_preview(Options const *options)
 	{
 		Preview *p = make_qt_preview(options);
 		if (p)
-			std::cerr << "Made QT preview window" << std::endl;
+			LOG(1, "Made QT preview window");
 		return p;
 	}
 #endif
@@ -34,7 +34,7 @@ Preview *make_preview(Options const *options)
 #if LIBEGL_PRESENT
 			Preview *p = make_egl_preview(options);
 			if (p)
-				std::cerr << "Made X/EGL preview window" << std::endl;
+				LOG(1, "Made X/EGL preview window");
 			return p;
 #else
 			throw std::runtime_error("egl libraries unavailable.");
@@ -47,7 +47,7 @@ Preview *make_preview(Options const *options)
 #if LIBDRM_PRESENT
 				Preview *p = make_drm_preview(options);
 				if (p)
-					std::cerr << "Made DRM preview window" << std::endl;
+					LOG(1, "Made DRM preview window");
 				return p;
 #else
 				throw std::runtime_error("drm libraries unavailable.");
@@ -55,7 +55,7 @@ Preview *make_preview(Options const *options)
 			}
 			catch (std::exception const &e)
 			{
-				std::cerr << "Preview window unavailable" << std::endl;
+				LOG(1, "Preview window unavailable");
 				return make_null_preview(options);
 			}
 		}

--- a/preview/qt_preview.cpp
+++ b/preview/qt_preview.cpp
@@ -70,7 +70,7 @@ public:
 		std::unique_lock lock(mutex_);
 		while (!pane_)
 			cond_var_.wait(lock);
-		if (options->verbose)
+		if (options->verbose >= 2)
 			std::cerr << "Made Qt preview" << std::endl;
 	}
 	~QtPreview()

--- a/preview/qt_preview.cpp
+++ b/preview/qt_preview.cpp
@@ -70,8 +70,7 @@ public:
 		std::unique_lock lock(mutex_);
 		while (!pane_)
 			cond_var_.wait(lock);
-		if (options->verbose >= 2)
-			std::cerr << "Made Qt preview" << std::endl;
+		LOG(2, "Made Qt preview");
 	}
 	~QtPreview()
 	{
@@ -109,8 +108,7 @@ public:
 		else if (info.colour_space == libcamera::ColorSpace::Rec709)
 			M = YUV2RGB[2];
 		else
-			std::cerr << "QtPreview: unexpected colour space " << libcamera::ColorSpace::toString(info.colour_space)
-					  << std::endl;
+			LOG(1, "QtPreview: unexpected colour space " << libcamera::ColorSpace::toString(info.colour_space));
 
 		// Possibly this should be locked in case a repaint is happening? In practice the risk
 		// is only that there might be some tearing, so I don't think we worry. We could speed


### PR DESCRIPTION
Add 3 separate verbosity levels, with 0 having no output, 1 having the
same effect as not setting -v previously, and 2 having the same effect
as setting -v previously.

Maintains same behaviour as setting/not setting -v previously, and just
adds level 0, which can be accessed by using -v 0.

Example uses:
Level 0: libcamera-still -v 0 ...
Level 1: libcamera-still ... or libcamera-still -v 1
Level 2: libcamera-still -v ... or libcamera-still -v 2

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>