### PR TITLE
libav: Cast out of const for av_find_input_format()

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -129,7 +129,7 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 
 void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo const &info)
 {
-	AVInputFormat *input_fmt = av_find_input_format("pulse");
+	AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
 
 	assert(in_fmt_ctx_ == nullptr);
 	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);


### PR DESCRIPTION
This stops a possible compiler warning. Sadly avformat_open_input needs a
non-const value, so input_fmt cannot be a const.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>