### PR TITLE
Add const to input_fmt

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -129,7 +129,11 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 
 void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo const &info)
 {
+#if LIBAVUTIL_VERSION_MAJOR < 58
 	AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
+#else
+	const AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
+#endif
 
 	assert(in_fmt_ctx_ == nullptr);
 	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -22,6 +22,7 @@ extern "C"
 #include "libavutil/hwcontext.h"
 #include "libavutil/hwcontext_drm.h"
 #include "libavutil/timestamp.h"
+#include "libavutil/version.h"
 #include "libswresample/swresample.h"
 }
 
@@ -67,4 +68,3 @@ private:
 	AVFormatContext *in_fmt_ctx_;
 	AVFormatContext *out_fmt_ctx_;
 };
-


### PR DESCRIPTION
Hey folks, ran into a compile error building this against ffmpeg 5.0 - the compiler really wanted the input_fmt to be const.