### PR TITLE
encoder: Add metadata output

### DIFF
--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -45,6 +45,7 @@ public:
 			encode_buffer_queue_.push(completed_request); // creates a new reference
 		}
 		encoder_->EncodeBuffer(buffer->planes()[0].fd.get(), span.size(), mem, info, timestamp_ns / 1000);
+		encoder_->metadataReady(completed_request->metadata);
 	}
 	VideoOptions *GetOptions() const { return static_cast<VideoOptions *>(options_.get()); }
 	void StopEncoder() { encoder_.reset(); }

--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -58,6 +58,10 @@ struct VideoOptions : public Options
 			 "Write output to a circular buffer of the given size (in MB) which is saved on exit")
 			("frames", value<unsigned int>(&frames)->default_value(0),
 			 "Run for the exact number of frames specified. This will override any timeout set.")
+			("metadata", value<std::string>(&metadata),
+			 "Save captured image metadata to a file or \"-\" for stdout")
+			("metadata-plain", value<bool>(&metadata_plain)->default_value(false)->implicit_value(true),
+			 "Save the metadata as plaintext rather than json (requires --metadata)")
 #if LIBAV_PRESENT
 			("libav-format", value<std::string>(&libav_format)->default_value(""),
 			 "Sets the libav encoder output format to use. "
@@ -104,6 +108,8 @@ struct VideoOptions : public Options
 	uint32_t segment;
 	size_t circular;
 	uint32_t frames;
+	std::string metadata;
+	bool metadata_plain;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{
@@ -154,5 +160,6 @@ struct VideoOptions : public Options
 		std::cerr << "    split: " << split << std::endl;
 		std::cerr << "    segment: " << segment << std::endl;
 		std::cerr << "    circular: " << circular << std::endl;
+		std::cerr << "    metadata: " << metadata << std::endl;
 	}
 };

--- a/encoder/encoder.cpp
+++ b/encoder/encoder.cpp
@@ -16,6 +16,34 @@
 #include "libav_encoder.hpp"
 #endif
 
+Encoder::Encoder(VideoOptions const *options) : options_(options), buf_metadata_(std::cout.rdbuf()), of_metadata_()
+{
+	if (!options->metadata.empty())
+	{
+		const std::string &filename = options_->metadata;
+
+		if (filename.compare("-"))
+		{
+			of_metadata_.open(filename, std::ios::out);
+			buf_metadata_ = of_metadata_.rdbuf();
+			if (!options->metadata_plain)
+			{
+				std::ostream out(buf_metadata_);
+				out << "[";
+			}
+		}
+	}
+}
+
+Encoder::~Encoder()
+{
+	if (!options_->metadata.empty() && !options_->metadata_plain)
+	{
+		std::ostream out(buf_metadata_);
+		out << std::endl << "]" << std::endl;
+	}
+}
+
 Encoder *Encoder::Create(VideoOptions const *options, const StreamInfo &info)
 {
 	if (strcasecmp(options->codec.c_str(), "yuv420") == 0)
@@ -29,4 +57,34 @@ Encoder *Encoder::Create(VideoOptions const *options, const StreamInfo &info)
 	else if (strcasecmp(options->codec.c_str(), "mjpeg") == 0)
 		return new MjpegEncoder(options);
 	throw std::runtime_error("Unrecognised codec " + options->codec);
+}
+
+void Encoder::metadataReady(const libcamera::ControlList &metadata)
+{
+	if (options_->metadata.empty())
+		return;
+
+	const libcamera::ControlIdMap *id_map = metadata.idMap();
+
+	std::ostream out(buf_metadata_);
+	if (options_->metadata_plain)
+	{
+		for (auto const &[id, val] : metadata)
+			out << id_map->at(id)->name() << "=" << val.toString() << std::endl;
+		out << std::endl;
+	}
+	else
+	{
+		out << (metadata_started_ ? "," : "") << std::endl << "{";
+		bool first_done = false;
+		for (auto const &[id, val] : metadata)
+		{
+			std::string arg_quote = (val.toString().find('/') != std::string::npos) ? "\"" : "";
+			out << (first_done ? "," : "") << std::endl
+				<< "    \"" << id_map->at(id)->name() << "\": " << arg_quote << val.toString() << arg_quote;
+			first_done = true;
+		}
+		out << std::endl << "}";
+		metadata_started_ = true;
+	}
 }

--- a/encoder/encoder.hpp
+++ b/encoder/encoder.hpp
@@ -20,8 +20,8 @@ class Encoder
 public:
 	static Encoder *Create(VideoOptions const *options, StreamInfo const &info);
 
-	Encoder(VideoOptions const *options) : options_(options) {}
-	virtual ~Encoder() {}
+	Encoder(VideoOptions const *options);
+	virtual ~Encoder();
 	// This is where the application sets the callback it gets whenever the encoder
 	// has finished with an input buffer, so the application can re-use it.
 	void SetInputDoneCallback(InputDoneCallback callback) { input_done_callback_ = callback; }
@@ -33,8 +33,13 @@ public:
 	// describing a DMABUF, and by a mmapped userland pointer.
 	virtual void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) = 0;
 
+	void metadataReady(const libcamera::ControlList &metadata);
+
 protected:
 	InputDoneCallback input_done_callback_;
 	OutputReadyCallback output_ready_callback_;
 	VideoOptions const *options_;
+	std::streambuf *buf_metadata_;
+	std::ofstream of_metadata_;
+	bool metadata_started_ = false;
 };


### PR DESCRIPTION
Add the option to output metadata to either a file or stdout, similar to in libcamera-still.

Defaults to a json output for useability, but can be switched to a pure text output like libcamera-still using --metadata-plain.

Example usage:
`libcamera-raw -t 10000 --metadata metadata.json`
`libcamera-vid -t 10000 --metadata metadata.json`
`libcamera-vid -t 10000 --metadata metadata.txt --metadata-plain`

Signed-off-by: William Vinnicombe <william.vinnicombe@raspberrypi.com>