### PR TITLE
William's metadata output for video

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.6)
 
 project(libcamera-still)
 add_executable(libcamera-still libcamera_still.cpp)
-target_link_libraries(libcamera-still libcamera_app images)
+target_link_libraries(libcamera-still libcamera_app outputs images)
 
 project(libcamera-vid)
 add_executable(libcamera-vid libcamera_vid.cpp)

--- a/apps/libcamera_raw.cpp
+++ b/apps/libcamera_raw.cpp
@@ -30,6 +30,7 @@ static void event_loop(LibcameraRaw &app)
 	VideoOptions const *options = app.GetOptions();
 	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
 	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
+	app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
 
 	app.OpenCamera();
 	app.ConfigureVideo(LibcameraRaw::FLAG_VIDEO_RAW);

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -65,6 +65,7 @@ static void event_loop(LibcameraEncoder &app)
 	VideoOptions const *options = app.GetOptions();
 	std::unique_ptr<Output> output = std::unique_ptr<Output>(Output::Create(options));
 	app.SetEncodeOutputReadyCallback(std::bind(&Output::OutputReady, output.get(), _1, _2, _3, _4));
+	app.SetMetadataReadyCallback(std::bind(&Output::MetadataReady, output.get(), _1));
 
 	app.OpenCamera();
 	app.ConfigureVideo(get_colourspace_flags(options->codec));

--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -12,6 +12,7 @@
 #include "encoder/encoder.hpp"
 
 typedef std::function<void(void *, size_t, int64_t, bool)> EncodeOutputReadyCallback;
+typedef std::function<void(libcamera::ControlList &)> MetadataReadyCallback;
 
 class LibcameraEncoder : public LibcameraApp
 {
@@ -29,6 +30,7 @@ public:
 	}
 	// This is callback when the encoder gives you the encoded output data.
 	void SetEncodeOutputReadyCallback(EncodeOutputReadyCallback callback) { encode_output_ready_callback_ = callback; }
+	void SetMetadataReadyCallback(MetadataReadyCallback callback) { metadata_ready_callback_ = callback; }
 	void EncodeBuffer(CompletedRequestPtr &completed_request, Stream *stream)
 	{
 		assert(encoder_);
@@ -72,6 +74,9 @@ private:
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);
 			if (encode_buffer_queue_.empty())
 				throw std::runtime_error("no buffer available to return");
+			CompletedRequestPtr &completed_request = encode_buffer_queue_.front();
+			if (metadata_ready_callback_ && !GetOptions()->metadata.empty())
+				metadata_ready_callback_(completed_request->metadata);
 			encode_buffer_queue_.pop(); // drop shared_ptr reference
 		}
 	}
@@ -79,4 +84,5 @@ private:
 	std::queue<CompletedRequestPtr> encode_buffer_queue_;
 	std::mutex encode_buffer_queue_mutex_;
 	EncodeOutputReadyCallback encode_output_ready_callback_;
+	MetadataReadyCallback metadata_ready_callback_;
 };

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -228,6 +228,13 @@ bool Options::Parse(int argc, char *argv[])
 	if (tuning_file != "-")
 		setenv("LIBCAMERA_RPI_TUNING_FILE", tuning_file.c_str(), 1);
 
+	if (strcasecmp(metadata_format.c_str(), "json") == 0)
+		metadata_format = "json";
+	else if (strcasecmp(metadata_format.c_str(), "txt") == 0)
+		metadata_format = "txt";
+	else
+		throw std::runtime_error("unrecognised metadata format " + metadata_format);
+
 	mode = Mode(mode_string);
 	viewfinder_mode = Mode(viewfinder_mode_string);
 
@@ -288,4 +295,6 @@ void Options::Print() const
 
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
+	std::cerr << "    metadata: " << metadata << std::endl;
+	std::cerr << "    metadata-format: " << metadata_format << std::endl;
 }

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -130,6 +130,10 @@ struct Options
 			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
+			("metadata", value<std::string>(&metadata),
+			 "Save captured image metadata to a file or \"-\" for stdout")
+			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
+			 "Format to save the metadata in, either txt or json (requires --metadata)")
 			;
 		// clang-format on
 	}
@@ -186,6 +190,8 @@ struct Options
 	Mode mode;
 	std::string viewfinder_mode_string;
 	Mode viewfinder_mode;
+	std::string metadata;
+	std::string metadata_format;
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/core/still_options.hpp
+++ b/core/still_options.hpp
@@ -46,8 +46,6 @@ struct StillOptions : public Options
 			 "Create a symbolic link with this name to most recent saved file")
 			("immediate", value<bool>(&immediate)->default_value(false)->implicit_value(true),
 			 "Perform first capture immediately, with no preview phase")
-			("metadata", value<std::string>(&metadata),
-			 "Save capture image metadata to a file or \"-\" for stdout")
 			;
 		// clang-format on
 	}
@@ -67,7 +65,6 @@ struct StillOptions : public Options
 	bool raw;
 	std::string latest;
 	bool immediate;
-	std::string metadata;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{
@@ -111,7 +108,6 @@ struct StillOptions : public Options
 		std::cerr << "    thumbnail quality: " << thumb_quality << std::endl;
 		std::cerr << "    latest: " << latest << std::endl;
 		std::cerr << "    immediate " << immediate << std::endl;
-		std::cerr << "    metadata " << metadata << std::endl;
 		for (auto &s : exif)
 			std::cerr << "    EXIF: " << s << std::endl;
 	}

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -14,7 +14,8 @@
 #include "output.hpp"
 
 Output::Output(VideoOptions const *options)
-	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0)
+	: options_(options), fp_timestamps_(nullptr), state_(WAITING_KEYFRAME), time_offset_(0), last_timestamp_(0),
+	  buf_metadata_(std::cout.rdbuf()), of_metadata_()
 {
 	if (!options->save_pts.empty())
 	{
@@ -22,6 +23,17 @@ Output::Output(VideoOptions const *options)
 		if (!fp_timestamps_)
 			throw std::runtime_error("Failed to open timestamp file " + options->save_pts);
 		fprintf(fp_timestamps_, "# timecode format v2\n");
+	}
+	if (!options->metadata.empty())
+	{
+		const std::string &filename = options_->metadata;
+
+		if (filename.compare("-"))
+		{
+			of_metadata_.open(filename, std::ios::out);
+			buf_metadata_ = of_metadata_.rdbuf();
+			start_metadata_output(buf_metadata_, options_->metadata_format);
+		}
 	}
 
 	enable_ = !options->pause;
@@ -31,6 +43,8 @@ Output::~Output()
 {
 	if (fp_timestamps_)
 		fclose(fp_timestamps_);
+	if (!options_->metadata.empty())
+		stop_metadata_output(buf_metadata_, options_->metadata_format);
 }
 
 void Output::Signal()
@@ -63,6 +77,14 @@ void Output::OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyf
 	{
 		timestampReady(last_timestamp_);
 	}
+
+	if (!options_->metadata.empty())
+	{
+		libcamera::ControlList metadata = metadata_queue_.front();
+		write_metadata(buf_metadata_, options_->metadata_format, metadata, !metadata_started_);
+		metadata_started_ = true;
+		metadata_queue_.pop();
+	}
 }
 
 void Output::timestampReady(int64_t timestamp)
@@ -90,4 +112,53 @@ Output *Output::Create(VideoOptions const *options)
 		return new FileOutput(options);
 	else
 		return new Output(options);
+}
+
+void Output::MetadataReady(libcamera::ControlList &metadata)
+{
+	if (options_->metadata.empty())
+		return;
+
+	metadata_queue_.push(metadata);
+}
+
+void start_metadata_output(std::streambuf *buf, std::string fmt)
+{
+	std::ostream out(buf);
+	if (fmt == "json")
+		out << "[" << std::endl;
+}
+
+void write_metadata(std::streambuf *buf, std::string fmt, libcamera::ControlList &metadata, bool first_write)
+{
+	std::ostream out(buf);
+	const libcamera::ControlIdMap *id_map = metadata.idMap();
+	if (fmt == "txt")
+	{
+		for (auto const &[id, val] : metadata)
+			out << id_map->at(id)->name() << "=" << val.toString() << std::endl;
+		out << std::endl;
+	}
+	else
+	{
+		if (!first_write)
+			out << "," << std::endl;
+		out << "{";
+		bool first_done = false;
+		for (auto const &[id, val] : metadata)
+		{
+			std::string arg_quote = (val.toString().find('/') != std::string::npos) ? "\"" : "";
+			out << (first_done ? "," : "") << std::endl
+				<< "    \"" << id_map->at(id)->name() << "\": " << arg_quote << val.toString() << arg_quote;
+			first_done = true;
+		}
+		out << std::endl << "}";
+	}
+}
+
+void stop_metadata_output(std::streambuf *buf, std::string fmt)
+{
+	std::ostream out(buf);
+	if (fmt == "json")
+		out << std::endl << "]" << std::endl;
 }

--- a/output/output.hpp
+++ b/output/output.hpp
@@ -22,6 +22,7 @@ public:
 	virtual ~Output();
 	virtual void Signal(); // a derived class might redefine what this means
 	void OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe);
+	void MetadataReady(libcamera::ControlList &metadata);
 
 protected:
 	enum Flag
@@ -46,4 +47,12 @@ private:
 	std::atomic<bool> enable_;
 	int64_t time_offset_;
 	int64_t last_timestamp_;
+	std::streambuf *buf_metadata_;
+	std::ofstream of_metadata_;
+	bool metadata_started_ = false;
+	std::queue<libcamera::ControlList> metadata_queue_;
 };
+
+void start_metadata_output(std::streambuf *buf, std::string fmt);
+void write_metadata(std::streambuf *buf, std::string fmt, libcamera::ControlList &metadata, bool first_write);
+void stop_metadata_output(std::streambuf *buf, std::string fmt);

--- a/utils/test.py
+++ b/utils/test.py
@@ -18,6 +18,7 @@ import os.path
 import subprocess
 import sys
 from timeit import default_timer as timer
+import numpy as np
 
 
 class TestFailure(Exception):
@@ -31,7 +32,7 @@ def check_exists(file, preamble):
         raise TestFailure(preamble + ": " + file + " not found")
 
 
-def clean_dir(dir, exts=('.jpg', '.png', '.bmp', '.dng', '.h264', '.mjpeg', '.raw', 'log.txt')):
+def clean_dir(dir, exts=('.jpg', '.png', '.bmp', '.dng', '.h264', '.mjpeg', '.raw', 'log.txt', 'timestamps.txt', 'metadata.json', 'metadata.txt')):
     for file in os.listdir(dir):
         if file.endswith(exts):
             os.remove(os.path.join(dir, file))
@@ -110,9 +111,61 @@ def test_hello(exe_dir, output_dir):
     print("libcamera-hello tests passed")
 
 
-def check_size(file, limit, presamble):
+def check_size(file, limit, preamble):
     if os.path.getsize(file) < limit:
         raise TestFailure(preamble + " failed, file " + file + " too small")
+
+
+def check_metadata(file, timestamp_file, preamble):
+    try:
+        with open(timestamp_file) as f:
+            times = np.loadtxt(f)
+    except Exception:
+        raise TestFailure(preamble + " - could not read timestamps from file")
+    try:
+        with open(file) as f:
+            data = json.load(f)
+    except Exception:
+        raise TestFailure(preamble + " - could not read data from file")
+    if len(data) != len(times):
+        raise TestFailure(preamble + " - metadata file has " + ("fewer" if len(data) < len(times) else "more") + " data points than timestamps file")
+    diffs = np.diff([x["SensorTimestamp"] for x in data]).astype(np.float64)
+    t_diffs = np.diff(times)
+    diffs /= 1000000
+    if not np.allclose(diffs[2:4], t_diffs[2:4], rtol=0.01):
+        print(diffs[2:4], t_diffs[2:4])
+        raise TestFailure(preamble + " - metadata times don't match timestamps")
+
+
+def check_single_metadata(file, preamble):
+    try:
+        with open(file) as f:
+            data = json.load(f)
+    except Exception:
+        raise TestFailure(preamble + " - could not read data from file")
+    if type(data) != dict:
+        raise TestFailure(preamble + " - metadata file is not a dict")
+    try:
+        if type(data["SensorTimestamp"]) != int:
+            raise TestFailure(preamble + " - sensor timestamp is not an int")
+    except KeyError:
+        raise TestFailure(preamble + " - sensor timestamp is not present")
+
+
+def check_metadata_txt(file, preamble):
+    try:
+        with open(file) as f:
+            line1 = f.readline()
+            line2 = f.readline()
+            line3 = f.readline()
+    except Exception:
+        raise TestFailure(preamble + " - could not read data from file")
+    try:
+        assert "=" in line1
+        assert "=" in line2
+        assert "=" in line3
+    except Exception:
+        raise TestFailure(preamble + " - metadata file does not contain expected data")
 
 
 def test_still(exe_dir, output_dir):
@@ -121,6 +174,8 @@ def test_still(exe_dir, output_dir):
     output_png = os.path.join(output_dir, 'test.png')
     output_bmp = os.path.join(output_dir, 'test.bmp')
     output_dng = os.path.join(output_dir, 'test.dng')
+    output_metadata = os.path.join(output_dir, 'metadata.json')
+    output_metadata_txt = os.path.join(output_dir, 'metadata.txt')
     logfile = os.path.join(output_dir, 'log.txt')
     print("Testing", executable)
     check_exists(executable, 'test_still')
@@ -169,6 +224,25 @@ def test_still(exe_dir, output_dir):
     check_size(os.path.join(output_dir, 'test001.jpg'), 1024, "test_still: timelapse test")
     if os.path.isfile(os.path.join(output_dir, 'test002.jpg')):
                raise("test_still: timelapse test, unexpected output file")
+
+    # "metadata test". Check that the json metadata file is written and looks sensible
+    print("    metadata test")
+    retcode, time_taken = run_executable([executable, '-t', '1000', '-o', output_jpg,
+                                          '--metadata', output_metadata], logfile)
+    check_retcode(retcode, "test_still: metadata test")
+    check_time(time_taken, 1.2, 8, "test_still: metadata test")
+    check_size(output_jpg, 1024, "test_still: metadata test")
+    check_single_metadata(output_metadata, "test_still: metadata test")
+
+    # "metadata txt test". Check that the txt metadata file is written and looks sensible
+    print("    metadata txt test")
+    retcode, time_taken = run_executable([executable, '-t', '1000', '-o', output_jpg,
+                                          '--metadata', output_metadata_txt,
+                                          '--metadata-format', 'txt'], logfile)
+    check_retcode(retcode, "test_still: metadata txt test")
+    check_time(time_taken, 1.2, 8, "test_still: metadata txt test")
+    check_size(output_jpg, 1024, "test_still: metadata txt test")
+    check_metadata_txt(output_metadata_txt, "test_still: metadata txt test")
 
     print("libcamera-still tests passed")
 
@@ -264,6 +338,8 @@ def test_vid(exe_dir, output_dir):
     output_circular = os.path.join(output_dir, 'circular.h264')
     output_pause = os.path.join(output_dir, 'pause.h264')
     output_timestamps = os.path.join(output_dir, 'timestamps.txt')
+    output_metadata = os.path.join(output_dir, 'metadata.json')
+    output_metadata_txt = os.path.join(output_dir, 'metadata.txt')
     logfile = os.path.join(output_dir, 'log.txt')
     print("Testing", executable)
     check_exists(executable, 'test_vid')
@@ -321,6 +397,26 @@ def test_vid(exe_dir, output_dir):
     check_time(time_taken, 2, 6, "test_vid: timestamp test")
     check_size(output_h264, 1024, "test_vid: timestamp test")
     check_timestamps(output_timestamps, "test_vid: timestamp test")
+
+    # "metadata test". Check that the json metadata file is written and looks sensible
+    print("    metadata test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '-o', output_h264,
+                                          '--save-pts', output_timestamps,
+                                          '--metadata', output_metadata], logfile)
+    check_retcode(retcode, "test_vid: metadata test")
+    check_time(time_taken, 2, 6, "test_vid: metadata test")
+    check_size(output_h264, 1024, "test_vid: metadata test")
+    check_metadata(output_metadata, output_timestamps, "test_vid: metadata test")
+
+    # "metadata txt test". Check that the txt metadata file is written and looks sensible
+    print("    metadata txt test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '-o', output_h264,
+                                          '--metadata', output_metadata_txt,
+                                          '--metadata-format', 'txt'], logfile)
+    check_retcode(retcode, "test_vid: metadata txt test")
+    check_time(time_taken, 2, 6, "test_vid: metadata txt test")
+    check_size(output_h264, 1024, "test_vid: metadata txt test")
+    check_metadata_txt(output_metadata_txt, "test_vid: metadata txt test")
 
     print("libcamera-vid tests passed")
 


### PR DESCRIPTION
These are William's commits that add metadata output for video streams, plus a couple more commits to add the same metadata formatting options to stills capture, and also to add some tests.

Things ended up a bit awkward because we wanted to get the Output objects to write the metadata, rather than hold up any other threads, but things are sufficiently compartmentalised that getting the metadata down there was slightly annoying. We've gone with copying the metadata into a queue in the output object, though an alternative would have been to hold on to a reference to the CompletedRequest instead.

On balance I think copying the metadata is OK - it only does it when it really has been requested, and holding onto the CompletedRequest might delay recycling the request back to libcamera which might also be undesirable.
