### PR TITLE
apps: Handle sensor timeouts

### DIFF
--- a/apps/libcamera_detect.cpp
+++ b/apps/libcamera_detect.cpp
@@ -59,6 +59,13 @@ static void event_loop(LibcameraDetectApp &app)
 	for (unsigned int count = 0;; count++)
 	{
 		LibcameraApp::Msg msg = app.Wait();
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type == LibcameraApp::MsgType::Quit)
 			return;
 

--- a/apps/libcamera_hello.cpp
+++ b/apps/libcamera_hello.cpp
@@ -27,6 +27,13 @@ static void event_loop(LibcameraApp &app)
 	for (unsigned int count = 0; ; count++)
 	{
 		LibcameraApp::Msg msg = app.Wait();
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type == LibcameraApp::MsgType::Quit)
 			return;
 		else if (msg.type != LibcameraApp::MsgType::RequestComplete)

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -42,6 +42,13 @@ static void event_loop(LibcameraJpegApp &app)
 	for (unsigned int count = 0; ; count++)
 	{
 		LibcameraApp::Msg msg = app.Wait();
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type == LibcameraApp::MsgType::Quit)
 			return;
 		else if (msg.type != LibcameraApp::MsgType::RequestComplete)

--- a/apps/libcamera_raw.cpp
+++ b/apps/libcamera_raw.cpp
@@ -42,6 +42,13 @@ static void event_loop(LibcameraRaw &app)
 	{
 		LibcameraRaw::Msg msg = app.Wait();
 
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type != LibcameraRaw::MsgType::RequestComplete)
 			throw std::runtime_error("unrecognised message!");
 		if (count == 0)

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -202,6 +202,13 @@ static void event_loop(LibcameraStillApp &app)
 	for (unsigned int count = 0; ; count++)
 	{
 		LibcameraApp::Msg msg = app.Wait();
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type == LibcameraApp::MsgType::Quit)
 			return;
 		else if (msg.type != LibcameraApp::MsgType::RequestComplete)

--- a/apps/libcamera_vid.cpp
+++ b/apps/libcamera_vid.cpp
@@ -81,6 +81,13 @@ static void event_loop(LibcameraEncoder &app)
 	for (unsigned int count = 0; ; count++)
 	{
 		LibcameraEncoder::Msg msg = app.Wait();
+		if (msg.type == LibcameraApp::MsgType::Timeout)
+		{
+			LOG_ERROR("ERROR: Device timeout detected, attempting a restart!!!");
+			app.StopCamera();
+			app.StartCamera();
+			continue;
+		}
 		if (msg.type == LibcameraEncoder::MsgType::Quit)
 			return;
 		else if (msg.type != LibcameraEncoder::MsgType::RequestComplete)

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -720,7 +720,14 @@ void LibcameraApp::makeRequests()
 void LibcameraApp::requestComplete(Request *request)
 {
 	if (request->status() == Request::RequestCancelled)
+	{
+		// If the request is cancelled while the camera is still running, it indicates
+		// a hardware timeout. Let the application handle this error.
+		if (camera_started_)
+			msg_queue_.Post(Msg(MsgType::Timeout));
+
 		return;
+	}
 
 	CompletedRequest *r = new CompletedRequest(sequence_++, request);
 	CompletedRequestPtr payload(r, [this](CompletedRequest *cr) { this->queueRequest(cr); });

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -60,6 +60,7 @@ public:
 	enum class MsgType
 	{
 		RequestComplete,
+		Timeout,
 		Quit
 	};
 	typedef std::variant<CompletedRequestPtr> MsgPayload;


### PR DESCRIPTION
Handle possible hardware timeout error conditions by doing a StopCamera() and subsequent StartCamera() to restart the sensor.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>