### PR TITLE
core: Fix a leaking request when preview windows are closed

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -777,6 +777,7 @@ void LibcameraApp::stopPreview()
 	}
 	preview_thread_.join();
 	preview_item_ = PreviewItem();
+	preview_completed_requests_.clear();
 }
 
 void LibcameraApp::previewThread()


### PR DESCRIPTION
Starting and stopping the preview window actually causes a camera request object to leak, and will ultimately lead to libcamera stalling. Not a use case we've ever considered before, but we may as well make it work!

Signed-off-by: David Plowman <david.plowman@raspberrypi.com>