### PR TITLE
encoder: Integrate libav codec encoder

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -23,7 +23,7 @@ struct VideoOptions : public Options
 		// clang-format off
 		options_.add_options()
 			("bitrate,b", value<uint32_t>(&bitrate)->default_value(0),
-			 "Set the bitrate for encoding, in bits/second (h264 only)")
+			 "Set the video bitrate for encoding, in bits/second (h264 only)")
 			("profile", value<std::string>(&profile),
 			 "Set the encoding profile (h264 only)")
 			("level", value<std::string>(&level),
@@ -33,7 +33,11 @@ struct VideoOptions : public Options
 			("inline", value<bool>(&inline_headers)->default_value(false)->implicit_value(true),
 			 "Force PPS/SPS header with every I frame (h264 only)")
 			("codec", value<std::string>(&codec)->default_value("h264"),
-			 "Set the codec to use, either h264, mjpeg or yuv420")
+			 "Set the codec to use, either h264, "
+#if LIBAV_PRESENT
+			  "libav, "
+#endif
+			  "mjpeg or yuv420")
 			("save-pts", value<std::string>(&save_pts),
 			 "Save a timestamp file with this name")
 			("quality,q", value<int>(&quality)->default_value(50),
@@ -54,6 +58,25 @@ struct VideoOptions : public Options
 			 "Write output to a circular buffer of the given size (in MB) which is saved on exit")
 			("frames", value<unsigned int>(&frames)->default_value(0),
 			 "Run for the exact number of frames specified. This will override any timeout set.")
+#if LIBAV_PRESENT
+			("libav-format", value<std::string>(&libav_format)->default_value(""),
+			 "Sets the libav encoder output format to use. "
+			 "Leave blank to try and deduce this from the filename.\n"
+			 "To list available formats, run  the \"ffmpeg -formats\" command.")
+			("libav-audio", value<bool>(&libav_audio)->default_value(false)->implicit_value(true),
+			 "Records an audio stream together with the video.")
+			("audio_codec", value<std::string>(&audio_codec)->default_value("aac"),
+			 "Sets the libav audio codec to use.\n"
+			 "To list available codecs, run  the \"ffmpeg -codecs\" command.")
+			("audio-device", value<std::string>(&audio_device)->default_value("default"),
+			 "Audio device to record from. To list the available devices, use the following command:\n"
+			 "pactl list | grep -A2 'Source #' | grep 'Name: '")
+			("audio-bitrate", value<uint32_t>(&audio_bitrate)->default_value(32768),
+			 "Set the audio bitrate for encoding, in bits/second.")
+			("av-sync", value<int32_t>(&av_sync)->default_value(0),
+			 "Add a time offset (in microseconds) to the audio stream, relative to the video stream. "
+			 "The offset value can be either positive or negative.")
+#endif
 			;
 		// clang-format on
 	}
@@ -64,6 +87,12 @@ struct VideoOptions : public Options
 	unsigned int intra;
 	bool inline_headers;
 	std::string codec;
+	std::string libav_format;
+	bool libav_audio;
+	std::string audio_codec;
+	std::string audio_device;
+	uint32_t audio_bitrate;
+	int32_t av_sync;
 	std::string save_pts;
 	int quality;
 	bool listen;
@@ -87,6 +116,8 @@ struct VideoOptions : public Options
 			height = 480;
 		if (strcasecmp(codec.c_str(), "h264") == 0)
 			codec = "h264";
+		else if (strcasecmp(codec.c_str(), "libav") == 0)
+			codec = "libav";
 		else if (strcasecmp(codec.c_str(), "yuv420") == 0)
 			codec = "yuv420";
 		else if (strcasecmp(codec.c_str(), "mjpeg") == 0)

--- a/encoder/CMakeLists.txt
+++ b/encoder/CMakeLists.txt
@@ -2,8 +2,30 @@ cmake_minimum_required(VERSION 3.6)
 
 include(GNUInstallDirs)
 
-add_library(encoders encoder.cpp null_encoder.cpp h264_encoder.cpp mjpeg_encoder.cpp)
-target_link_libraries(encoders jpeg)
+set(LIBAV_PRESENT 0)
+set(SRC encoder.cpp null_encoder.cpp h264_encoder.cpp mjpeg_encoder.cpp)
+set(TARGET_LIBS images)
+
+#pkg_check_modules(LIBAV REQUIRED IMPORTED_TARGET ffspeg)
+pkg_check_modules(LIBAV QUIET IMPORTED_TARGET
+    libavcodec
+    libavdevice
+    libavformat
+    libswresample
+)
+
+if (LIBAV_FOUND)
+    include_directories(${LIBAV_INCLUDE_DIRS})
+    set(SRC ${SRC} libav_encoder.cpp)
+    set(TARGET_LIBS ${TARGET_LIBS} ${LIBAV_LIBRARIES})
+    set(LIBAV_PRESENT 1)
+    message(STATUS "libavcodec found:")
+    message(STATUS "    libraries: ${LIBAV_LIBRARIES}")
+endif()
+
+add_library(encoders ${SRC})
+target_link_libraries(encoders ${TARGET_LIBS})
+target_compile_definitions(encoders PUBLIC LIBAV_PRESENT=${LIBAV_PRESENT})
 
 install(TARGETS encoders LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/encoder/encoder.cpp
+++ b/encoder/encoder.cpp
@@ -12,12 +12,20 @@
 #include "mjpeg_encoder.hpp"
 #include "null_encoder.hpp"
 
+#if LIBAV_PRESENT
+#include "libav_encoder.hpp"
+#endif
+
 Encoder *Encoder::Create(VideoOptions const *options, const StreamInfo &info)
 {
 	if (strcasecmp(options->codec.c_str(), "yuv420") == 0)
 		return new NullEncoder(options);
 	else if (strcasecmp(options->codec.c_str(), "h264") == 0)
 		return new H264Encoder(options, info);
+#if LIBAV_PRESENT
+	else if (strcasecmp(options->codec.c_str(), "libav") == 0)
+		return new LibAvEncoder(options, info);
+#endif
 	else if (strcasecmp(options->codec.c_str(), "mjpeg") == 0)
 		return new MjpegEncoder(options);
 	throw std::runtime_error("Unrecognised codec " + options->codec);

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -1,0 +1,540 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2022, Raspberry Pi Ltd
+ *
+ * libav_encoder.cpp - libav video encoder.
+ */
+
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+
+#include <libdrm/drm_fourcc.h>
+#include <linux/videodev2.h>
+
+#include <chrono>
+#include <iostream>
+
+#include "libav_encoder.hpp"
+
+void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const &info)
+{
+	const std::string codec_name("h264_v4l2m2m");
+
+	const AVCodec *codec = avcodec_find_encoder_by_name(codec_name.c_str());
+	if (!codec)
+		throw std::runtime_error("libav: cannot find video encoder " + codec_name);
+
+	codec_ctx_[Video] = avcodec_alloc_context3(codec);
+	if (!codec_ctx_[Video])
+		throw std::runtime_error("libav: Cannot allocate video context");
+
+	codec_ctx_[Video]->width = info.width;
+	codec_ctx_[Video]->height = info.height;
+	// usec timebase
+	codec_ctx_[Video]->time_base = { 1, 1000 * 1000 };
+	codec_ctx_[Video]->framerate = { (int)(options->framerate * 1000), 1000 };
+	codec_ctx_[Video]->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+	codec_ctx_[Video]->sw_pix_fmt = AV_PIX_FMT_YUV420P;
+
+	if (info.colour_space)
+	{
+		using libcamera::ColorSpace;
+
+		static const std::map<ColorSpace::Primaries, AVColorPrimaries> pri_map = {
+			{ ColorSpace::Primaries::Smpte170m, AVCOL_PRI_SMPTE170M },
+			{ ColorSpace::Primaries::Rec709, AVCOL_PRI_BT709 },
+			{ ColorSpace::Primaries::Rec2020, AVCOL_PRI_BT2020 },
+		};
+
+		static const std::map<ColorSpace::TransferFunction, AVColorTransferCharacteristic> tf_map = {
+			{ ColorSpace::TransferFunction::Linear, AVCOL_TRC_LINEAR },
+			{ ColorSpace::TransferFunction::Srgb, AVCOL_TRC_IEC61966_2_1 },
+			{ ColorSpace::TransferFunction::Rec709, AVCOL_TRC_BT709 },
+		};
+
+		static const std::map<ColorSpace::YcbcrEncoding, AVColorSpace> cs_map = {
+			{ ColorSpace::YcbcrEncoding::None, AVCOL_SPC_UNSPECIFIED },
+			{ ColorSpace::YcbcrEncoding::Rec601, AVCOL_SPC_SMPTE170M },
+			{ ColorSpace::YcbcrEncoding::Rec709, AVCOL_SPC_BT709 },
+			{ ColorSpace::YcbcrEncoding::Rec2020, AVCOL_SPC_BT2020_CL },
+		};
+
+		auto it_p = pri_map.find(info.colour_space->primaries);
+		if (it_p == pri_map.end())
+			throw std::runtime_error("libav: no match for colour primaries in " + info.colour_space->toString());
+		codec_ctx_[Video]->color_primaries = it_p->second;
+
+		auto it_tf = tf_map.find(info.colour_space->transferFunction);
+		if (it_tf == tf_map.end())
+			throw std::runtime_error("libav: no match for transfer function in " + info.colour_space->toString());
+		codec_ctx_[Video]->color_trc = it_tf->second;
+
+		auto it_cs = cs_map.find(info.colour_space->ycbcrEncoding);
+		if (it_cs == cs_map.end())
+			throw std::runtime_error("libav: no match for ycbcr encoding in " + info.colour_space->toString());
+		codec_ctx_[Video]->colorspace = it_cs->second;
+
+		codec_ctx_[Video]->color_range =
+			info.colour_space->range == ColorSpace::Range::Full ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
+	}
+
+	// Apply any options->
+	if (options->bitrate)
+		codec_ctx_[Video]->bit_rate = options->bitrate;
+
+	if (!options->profile.empty())
+	{
+		static const std::map<std::string, int> profile_map = {
+			{ "baseline", FF_PROFILE_H264_BASELINE },
+			{ "main", FF_PROFILE_H264_MAIN },
+			{ "high", FF_PROFILE_H264_HIGH }
+		};
+
+		auto it = profile_map.find(options->profile);
+		if (it == profile_map.end())
+			throw std::runtime_error("libav: no such profile " + options->profile);
+
+		codec_ctx_[Video]->profile = it->second;
+	}
+
+	codec_ctx_[Video]->level = options->level.empty() ? FF_LEVEL_UNKNOWN : std::stof(options->level) * 10;
+
+	if (options->intra)
+		codec_ctx_[Video]->gop_size = options->intra;
+
+	assert(out_fmt_ctx_ == nullptr);
+	avformat_alloc_output_context2(&out_fmt_ctx_, nullptr,
+								   options->libav_format.empty() ? nullptr : options->libav_format.c_str(),
+								   options->output.c_str());
+	if (!out_fmt_ctx_)
+		throw std::runtime_error("libav: cannot allocate output context");
+
+	if (out_fmt_ctx_->oformat->flags & AVFMT_GLOBALHEADER)
+		codec_ctx_[Video]->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+	int ret = avcodec_open2(codec_ctx_[Video], codec, nullptr);
+	if (ret < 0)
+		throw std::runtime_error("libav: unable to open video codec: " + std::to_string(ret));
+
+	// Video stream
+	stream_[Video] = avformat_new_stream(out_fmt_ctx_, codec);
+	if (!stream_[Video])
+		throw std::runtime_error("libav: cannot allocate stream for vidout output context");
+
+	stream_[Video]->time_base = codec_ctx_[Video]->time_base;
+	avcodec_parameters_from_context(stream_[Video]->codecpar, codec_ctx_[Video]);
+}
+
+void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo const &info)
+{
+	AVInputFormat *input_fmt = av_find_input_format("pulse");
+
+	assert(in_fmt_ctx_ == nullptr);
+	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);
+	if (ret < 0)
+		throw std::runtime_error("libav: cannot open pulseaudio input device " + options->audio_device);
+
+	avformat_find_stream_info(in_fmt_ctx_, nullptr);
+
+	stream_[AudioIn] = nullptr;
+	for (unsigned int i = 0; i < in_fmt_ctx_->nb_streams; i++)
+	{
+		if (in_fmt_ctx_->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+		{
+			stream_[AudioIn] = in_fmt_ctx_->streams[i];
+			break;
+		}
+	}
+
+	if (!stream_[AudioIn])
+		throw std::runtime_error("libav: couldn't find a audio stream.");
+
+	const AVCodec *codec = avcodec_find_decoder(stream_[AudioIn]->codecpar->codec_id);
+	codec_ctx_[AudioIn] = avcodec_alloc_context3(codec);
+	avcodec_parameters_to_context(codec_ctx_[AudioIn], stream_[AudioIn]->codecpar);
+	// usec timebase
+	codec_ctx_[AudioIn]->time_base = { 1, 1000 * 1000 };
+	ret = avcodec_open2(codec_ctx_[AudioIn], codec, nullptr);
+	if (ret < 0)
+		throw std::runtime_error("libav: unable to open audio in codec: " + std::to_string(ret));
+}
+
+void LibAvEncoder::initAudioOutCodec(VideoOptions const *options, StreamInfo const &info)
+{
+	const AVCodec *codec = avcodec_find_encoder_by_name(options->audio_codec.c_str());
+	if (!codec)
+		throw std::runtime_error("libav: cannot find audio encoder " + options->audio_codec);
+
+	codec_ctx_[AudioOut] = avcodec_alloc_context3(codec);
+	if (!codec_ctx_[AudioOut])
+		throw std::runtime_error("libav: cannot allocate audio in context");
+
+	assert(stream_[AudioIn]);
+	codec_ctx_[AudioOut]->channels = stream_[AudioIn]->codecpar->channels;
+	codec_ctx_[AudioOut]->channel_layout = av_get_default_channel_layout(stream_[AudioIn]->codecpar->channels);
+	codec_ctx_[AudioOut]->sample_rate = stream_[AudioIn]->codecpar->sample_rate;
+	codec_ctx_[AudioOut]->sample_fmt = codec->sample_fmts[0];
+	codec_ctx_[AudioOut]->bit_rate = options->audio_bitrate;
+	// usec timebase
+	codec_ctx_[AudioOut]->time_base = { 1, 1000 * 1000 };
+
+	assert(out_fmt_ctx_);
+	if (out_fmt_ctx_->oformat->flags & AVFMT_GLOBALHEADER)
+		codec_ctx_[AudioOut]->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+	int ret = avcodec_open2(codec_ctx_[AudioOut], codec, nullptr);
+	if (ret < 0)
+		throw std::runtime_error("libav: unable to open audio codec: " + std::to_string(ret));
+
+	stream_[AudioOut] = avformat_new_stream(out_fmt_ctx_, codec);
+	if (!stream_[AudioOut])
+		throw std::runtime_error("libav: cannot allocate stream for audio output context");
+
+	stream_[AudioOut]->time_base = codec_ctx_[AudioOut]->time_base;
+	avcodec_parameters_from_context(stream_[AudioOut]->codecpar, codec_ctx_[AudioOut]);
+}
+
+LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
+	: Encoder(options), output_ready_(false), abort_video_(false), abort_audio_(false),
+	  video_start_ts_(0), audio_start_ts_(0), in_fmt_ctx_(nullptr), out_fmt_ctx_(nullptr)
+{
+	avdevice_register_all();
+
+	if (options->verbose)
+		av_log_set_level(AV_LOG_VERBOSE);
+
+	initVideoCodec(options, info);
+	if (options->libav_audio)
+	{
+		initAudioInCodec(options, info);
+		initAudioOutCodec(options, info);
+		av_dump_format(in_fmt_ctx_, 0, options_->audio_device.c_str(), 0);
+	}
+
+	av_dump_format(out_fmt_ctx_, 0, options_->output.c_str(), 1);
+
+	if (options->verbose)
+		std::cerr << "libav: codec init completed" << std::endl;
+
+	video_thread_ = std::thread(&LibAvEncoder::videoThread, this);
+
+	if (options->libav_audio)
+		audio_thread_ = std::thread(&LibAvEncoder::audioThread, this);
+}
+
+LibAvEncoder::~LibAvEncoder()
+{
+	if (options_->libav_audio)
+	{
+		abort_audio_ = true;
+		audio_thread_.join();
+	}
+
+	abort_video_ = true;
+	video_thread_.join();
+
+	avformat_free_context(out_fmt_ctx_);
+	avcodec_free_context(&codec_ctx_[Video]);
+
+	if (options_->libav_audio)
+	{
+		avformat_free_context(in_fmt_ctx_);
+		avcodec_free_context(&codec_ctx_[AudioIn]);
+		avcodec_free_context(&codec_ctx_[AudioOut]);
+	}
+
+	if (options_->verbose)
+		std::cerr << "libav: codec closed" << std::endl;
+}
+
+void LibAvEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us)
+{
+	AVFrame *frame = av_frame_alloc();
+	if (!frame)
+		throw std::runtime_error("libav: could not allocate AVFrame");
+
+	if (!video_start_ts_)
+		video_start_ts_ = timestamp_us;
+
+	frame->format = AV_PIX_FMT_DRM_PRIME;
+	frame->width = info.width;
+	frame->height = info.height;
+	frame->linesize[0] = info.stride;
+	frame->pts = timestamp_us - video_start_ts_ + (options_->av_sync < 0 ? -options_->av_sync : 0);
+
+	frame->buf[0] = av_buffer_alloc(sizeof(AVDRMFrameDescriptor));
+	frame->data[0] = frame->buf[0]->data;
+
+	AVDRMFrameDescriptor *desc = (AVDRMFrameDescriptor *)frame->data[0];
+	desc->nb_objects = 1;
+	desc->objects[0].fd = fd;
+	desc->objects[0].size = size;
+	desc->objects[0].format_modifier = DRM_FORMAT_MOD_INVALID;
+
+	desc->nb_layers = 1;
+	desc->layers[0].format = DRM_FORMAT_YUV420;
+	desc->layers[0].nb_planes = 3;
+	desc->layers[0].planes[0].object_index = 0;
+	desc->layers[0].planes[0].offset = 0;
+	desc->layers[0].planes[0].pitch = info.stride;
+	desc->layers[0].planes[1].object_index = 0;
+	desc->layers[0].planes[1].offset = info.stride * info.height;
+	desc->layers[0].planes[1].pitch = info.stride >> 1;
+	desc->layers[0].planes[2].object_index = 0;
+	desc->layers[0].planes[2].offset = info.stride * info.height * 5 / 4;
+	desc->layers[0].planes[2].pitch = info.stride >> 1;
+
+	std::scoped_lock<std::mutex> lock(video_mutex_);
+	frame_queue_.push(frame);
+	video_cv_.notify_all();
+}
+
+void LibAvEncoder::initOutput()
+{
+	int ret;
+
+	// Copy the global header from the video encode context once the first frame
+	// has been encoded.
+	avcodec_parameters_from_context(stream_[Video]->codecpar, codec_ctx_[Video]);
+
+	char err[64];
+	if (!(out_fmt_ctx_->flags & AVFMT_NOFILE))
+	{
+		ret = avio_open2(&out_fmt_ctx_->pb, options_->output.c_str(), AVIO_FLAG_WRITE, nullptr, nullptr);
+		if (ret < 0)
+		{
+			av_strerror(ret, err, sizeof(err));
+			throw std::runtime_error("libav: unable to open output mux for " + options_->output + ": " + err);
+		}
+	}
+
+	ret = avformat_write_header(out_fmt_ctx_, nullptr);
+	if (ret < 0)
+	{
+		av_strerror(ret, err, sizeof(err));
+		throw std::runtime_error("libav: unable write output mux header for " + options_->output + ": " + err);
+	}
+}
+
+void LibAvEncoder::deinitOutput()
+{
+	if (!out_fmt_ctx_)
+		return;
+
+	av_write_trailer(out_fmt_ctx_);
+
+	if (!(out_fmt_ctx_->flags & AVFMT_NOFILE))
+		avio_closep(&out_fmt_ctx_->pb);
+}
+
+void LibAvEncoder::encode(AVPacket *pkt, unsigned int stream_id)
+{
+	int ret = 0;
+
+	while (ret >= 0)
+	{
+		ret = avcodec_receive_packet(codec_ctx_[stream_id], pkt);
+
+		if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF)
+		{
+			av_packet_unref(pkt);
+			break;
+		}
+		else if (ret < 0)
+			throw std::runtime_error("libav: error receiving packet: " + std::to_string(ret));
+
+		// Initialise the ouput mux on the first received video packet, as we may need
+		// to copy global header data from the encoder.
+		if (stream_id == Video && !output_ready_)
+		{
+			initOutput();
+			output_ready_ = true;
+		}
+
+		pkt->stream_index = stream_id;
+		pkt->pos = -1;
+		pkt->duration = 0;
+
+		// Rescale from the codec timebase to the stream timebase.
+		av_packet_rescale_ts(pkt, codec_ctx_[stream_id]->time_base, out_fmt_ctx_->streams[stream_id]->time_base);
+
+		std::scoped_lock<std::mutex> lock(output_mutex_);
+		// pkt is now blank (av_interleaved_write_frame() takes ownership of
+		// its contents and resets pkt), so that no unreferencing is necessary.
+		// This would be different if one used av_write_frame().
+		ret = av_interleaved_write_frame(out_fmt_ctx_, pkt);
+		if (ret < 0)
+			throw std::runtime_error("libav: error writing output: " + std::to_string(ret));
+	}
+}
+
+void LibAvEncoder::videoThread()
+{
+	AVPacket *pkt = av_packet_alloc();
+	AVFrame *frame = nullptr;
+
+	while (true)
+	{
+		{
+			std::unique_lock<std::mutex> lock(video_mutex_);
+			while (true)
+			{
+				using namespace std::chrono_literals;
+				// Must check the abort first, to allow items in the output
+				// queue to have a callback.
+				if (abort_video_ && frame_queue_.empty())
+					goto done;
+
+				if (!frame_queue_.empty())
+				{
+					frame = frame_queue_.front();
+					frame_queue_.pop();
+					break;
+				}
+				else
+					video_cv_.wait_for(lock, 200ms);
+			}
+		}
+
+		int ret = avcodec_send_frame(codec_ctx_[Video], frame);
+		if (ret < 0)
+			throw std::runtime_error("libav: error encoding frame: " + std::to_string(ret));
+
+		input_done_callback_(nullptr);
+
+		encode(pkt, Video);
+		av_frame_free(&frame);
+	}
+
+done:
+	// Flush the encoder
+	avcodec_send_frame(codec_ctx_[Video], nullptr);
+	encode(pkt, Video);
+
+	av_packet_free(&pkt);
+	deinitOutput();
+}
+
+void LibAvEncoder::audioThread()
+{
+	constexpr AVSampleFormat required_fmt = AV_SAMPLE_FMT_FLTP;
+	// Amount of time to pre-record audio into the fifo before the first video frame.
+	constexpr std::chrono::milliseconds pre_record_time(10);
+
+	SwrContext *conv;
+	AVAudioFifo *fifo;
+
+	conv = swr_alloc_set_opts(nullptr, av_get_default_channel_layout(codec_ctx_[AudioOut]->channels),
+							  required_fmt, stream_[AudioOut]->codecpar->sample_rate,
+							  av_get_default_channel_layout(codec_ctx_[AudioIn]->channels),
+							  (AVSampleFormat)stream_[AudioIn]->codecpar->format,
+							  stream_[AudioIn]->codecpar->sample_rate, 0, nullptr);
+	swr_init(conv);
+
+	// 2 seconds FIFO buffer
+	fifo = av_audio_fifo_alloc(required_fmt, codec_ctx_[AudioOut]->channels, codec_ctx_[AudioOut]->sample_rate * 2);
+
+	AVPacket *in_pkt = av_packet_alloc();
+	AVPacket *out_pkt = av_packet_alloc();
+	AVFrame *in_frame = av_frame_alloc();
+
+	while (!abort_audio_)
+	{
+		int ret;
+
+		// Audio In
+		ret = av_read_frame(in_fmt_ctx_, in_pkt);
+		if (ret < 0)
+			throw std::runtime_error("libav: cannot read audio in frame");
+
+		ret = avcodec_send_packet(codec_ctx_[AudioIn], in_pkt);
+		if (ret < 0)
+			throw std::runtime_error("libav: cannot send pkt for decoding audio in");
+
+		ret = avcodec_receive_frame(codec_ctx_[AudioIn], in_frame);
+		if (ret && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)
+			throw std::runtime_error("libav: error getting decoded audio in frame");
+
+		// Audio Resample/Conversion
+		uint8_t **samples = nullptr;
+		ret = av_samples_alloc_array_and_samples(&samples, NULL, codec_ctx_[AudioOut]->channels, in_frame->nb_samples,
+												 required_fmt, 0);
+		if (ret < 0)
+			throw std::runtime_error("libav: failed to alloc sample array");
+
+		ret = swr_convert(conv, samples, in_frame->nb_samples, (const uint8_t **)in_frame->extended_data,
+						  in_frame->nb_samples);
+		if (ret < 0)
+			throw std::runtime_error("libav: swr_convert failed");
+
+		// Pre-record some audio before the encoded video frame is available.
+		if (!output_ready_)
+		{
+			using namespace std::chrono_literals;
+			// Pre-record number of samples needed.
+			const unsigned int ns = pre_record_time * stream_[AudioOut]->codecpar->sample_rate / 1s;
+			unsigned int r = ns % codec_ctx_[AudioOut]->frame_size;
+			// Number of pre-record samples rounded to the frame size.
+			unsigned int ps = !r ? ns : ns + codec_ctx_[AudioOut]->frame_size - r;
+			// FIFO size with samples from the next frame added.
+			unsigned int fs = av_audio_fifo_size(fifo) + in_frame->nb_samples;
+			if (fs > ps)
+				av_audio_fifo_drain(fifo, fs - ps);
+		}
+
+		if (av_audio_fifo_space(fifo) < in_frame->nb_samples)
+		{
+			std::cerr << "libav: Draining audio fifo, configure a larger size" << std::endl;
+			av_audio_fifo_drain(fifo, in_frame->nb_samples);
+		}
+
+		av_audio_fifo_write(fifo, (void **)samples, in_frame->nb_samples);
+		av_freep(&samples[0]);
+
+		int64_t in_pts = in_frame->pts;
+		av_frame_unref(in_frame);
+		av_packet_unref(in_pkt);
+
+		// Not yet ready to generate encoded audio!
+		if (!output_ready_)
+			continue;
+
+		if (audio_start_ts_ == 0)
+			audio_start_ts_ = in_pts;
+
+		// Audio Out
+		while (av_audio_fifo_size(fifo) >= codec_ctx_[AudioOut]->frame_size)
+		{
+			AVFrame *out_frame = av_frame_alloc();
+			out_frame->nb_samples = codec_ctx_[AudioOut]->frame_size;
+			out_frame->channels = codec_ctx_[AudioOut]->channels;
+			out_frame->channel_layout = av_get_default_channel_layout(codec_ctx_[AudioOut]->channels);
+			out_frame->format = required_fmt;
+			out_frame->sample_rate = codec_ctx_[AudioOut]->sample_rate;
+
+			av_frame_get_buffer(out_frame, 0);
+			av_audio_fifo_read(fifo, (void **)out_frame->data, codec_ctx_[AudioOut]->frame_size);
+
+			out_frame->pts = in_pts - audio_start_ts_ + (options_->av_sync > 0 ? options_->av_sync : 0);
+			ret = avcodec_send_frame(codec_ctx_[AudioOut], out_frame);
+			if (ret < 0)
+				throw std::runtime_error("libav: error encoding frame: " + std::to_string(ret));
+
+			encode(out_pkt, AudioOut);
+			av_frame_free(&out_frame);
+		}
+	}
+
+	// Flush the encoder
+	avcodec_send_frame(codec_ctx_[AudioOut], nullptr);
+	encode(out_pkt, AudioOut);
+
+	swr_free(&conv);
+	av_audio_fifo_free(fifo);
+
+	av_packet_free(&in_pkt);
+	av_packet_free(&out_pkt);
+	av_frame_free(&in_frame);
+}

--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -1,0 +1,71 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2022, Raspberry Pi Ltd
+ *
+ * libav_encoder.hpp - libav video encoder.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+extern "C"
+{
+#include "libavcodec/avcodec.h"
+#include "libavdevice/avdevice.h"
+#include "libavformat/avformat.h"
+#include "libavutil/audio_fifo.h"
+#include "libavutil/hwcontext.h"
+#include "libavutil/hwcontext_drm.h"
+#include "libavutil/timestamp.h"
+#include "libswresample/swresample.h"
+}
+
+#include "encoder.hpp"
+
+class LibAvEncoder : public Encoder
+{
+public:
+	LibAvEncoder(VideoOptions const *options, StreamInfo const &info);
+	~LibAvEncoder();
+	// Encode the given DMABUF.
+	void EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const &info, int64_t timestamp_us) override;
+
+private:
+	void initVideoCodec(VideoOptions const *options, StreamInfo const &info);
+	void initAudioInCodec(VideoOptions const *options, StreamInfo const &info);
+	void initAudioOutCodec(VideoOptions const *options, StreamInfo const &info);
+
+	void initOutput();
+	void deinitOutput();
+	void encode(AVPacket *pkt, unsigned int stream_id);
+
+	void videoThread();
+	void audioThread();
+
+	std::atomic<bool> output_ready_;
+	bool abort_video_;
+	bool abort_audio_;
+	int fd_;
+	uint64_t video_start_ts_;
+	uint64_t audio_start_ts_;
+
+	std::queue<AVFrame *> frame_queue_;
+	std::mutex video_mutex_;
+	std::mutex output_mutex_;
+	std::condition_variable video_cv_;
+	std::thread video_thread_;
+	std::thread audio_thread_;
+
+	// The ordering in the enum below must not change!
+	enum Context { Video = 0, AudioOut = 1, AudioIn = 2 };
+	AVCodecContext *codec_ctx_[3];
+	AVStream *stream_[3];
+	AVFormatContext *in_fmt_ctx_;
+	AVFormatContext *out_fmt_ctx_;
+};
+

--- a/output/output.cpp
+++ b/output/output.cpp
@@ -70,6 +70,9 @@ void Output::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint32_t
 
 Output *Output::Create(VideoOptions const *options)
 {
+	if (options->codec == "libav")
+		return new Output(options);
+
 	if (strncmp(options->output.c_str(), "udp://", 6) == 0 || strncmp(options->output.c_str(), "tcp://", 6) == 0)
 		return new NetOutput(options);
 	else if (options->circular)


### PR DESCRIPTION
This change adds a new encoder target (--codec libav) that uses the libav
libary to encode H.264 through the V4L2 hardware encoder together with optional
audio encoding.  Using libav also allows writing out to file containers such as
mkv or mp4 instead of elementary H.264 streams.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
