### PR TITLE
libav: Add option to choose the audio source (alsa/pulseaudio)

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -68,9 +68,14 @@ struct VideoOptions : public Options
 			("audio-codec", value<std::string>(&audio_codec)->default_value("aac"),
 			 "Sets the libav audio codec to use.\n"
 			 "To list available codecs, run  the \"ffmpeg -codecs\" command.")
+			("audio-source", value<std::string>(&audio_source)->default_value("pulse"),
+			 "Audio source to record from. Valid options are \"pulse\" and \"alsa\"")
 			("audio-device", value<std::string>(&audio_device)->default_value("default"),
-			 "Audio device to record from. To list the available devices, use the following command:\n"
-			 "pactl list | grep -A2 'Source #' | grep 'Name: '")
+			 "Audio device to record from.  To list the available devices,\n"
+			 "for pulseaudio, use the following command:\n"
+			 "\"pactl list | grep -A2 'Source #' | grep 'Name: '\"\n"
+			 "or for alsa, use the following command:\n"
+			 "\"arecord -L\"")
 			("audio-bitrate", value<uint32_t>(&audio_bitrate)->default_value(32768),
 			 "Set the audio bitrate for encoding, in bits/second.")
 			("audio-samplerate", value<uint32_t>(&audio_samplerate)->default_value(0),
@@ -93,6 +98,7 @@ struct VideoOptions : public Options
 	bool libav_audio;
 	std::string audio_codec;
 	std::string audio_device;
+	std::string audio_source;
 	uint32_t audio_bitrate;
 	uint32_t audio_samplerate;
 	int32_t av_sync;

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -140,9 +140,9 @@ void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const 
 void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo const &info)
 {
 #if LIBAVUTIL_VERSION_MAJOR < 58
-	AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
+	AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format(options->audio_source.c_str());
 #else
-	const AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format("pulse");
+	const AVInputFormat *input_fmt = (AVInputFormat *)av_find_input_format(options->audio_source.c_str());
 #endif
 
 	assert(in_fmt_ctx_ == nullptr);
@@ -438,7 +438,7 @@ done:
 
 void LibAvEncoder::audioThread()
 {
-	constexpr AVSampleFormat required_fmt = AV_SAMPLE_FMT_FLTP;
+	const AVSampleFormat required_fmt = codec_ctx_[AudioOut]->sample_fmt;
 	// Amount of time to pre-record audio into the fifo before the first video frame.
 	constexpr std::chrono::milliseconds pre_record_time(10);
 


### PR DESCRIPTION
Add a new command line arguement (--audio-source) to allow the user to
select between an alsa or pulseaudio source device.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
