### PR TITLE
Add YUV save to stdout on "-" path

### DIFF
--- a/image/yuv.cpp
+++ b/image/yuv.cpp
@@ -20,7 +20,7 @@ static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, Stream
 			throw std::runtime_error("both width and height must be even");
 		if (mem.size() != 1)
 			throw std::runtime_error("incorrect number of planes in YUV420 data");
-		FILE *fp = fopen(filename.c_str(), "w");
+		FILE *fp = filename == "-" ? stdout : fopen(filename.c_str(), "w");
 		if (!fp)
 			throw std::runtime_error("failed to open file " + filename);
 		try
@@ -47,7 +47,8 @@ static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, Stream
 		}
 		catch (std::exception const &e)
 		{
-			fclose(fp);
+			if (fp != stdout)
+				fclose(fp);
 			throw;
 		}
 	}
@@ -62,7 +63,8 @@ static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamIn
 	{
 		if ((info.width & 1) || (info.height & 1))
 			throw std::runtime_error("both width and height must be even");
-		FILE *fp = fopen(filename.c_str(), "w");
+
+		FILE *fp = filename == "-" ? stdout : fopen(filename.c_str(), "w");
 		if (!fp)
 			throw std::runtime_error("failed to open file " + filename);
 		try
@@ -94,11 +96,13 @@ static void yuyv_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamIn
 				if (fwrite(&row[0], info.width / 2, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
-			fclose(fp);
+			if (fp != stdout)
+				fclose(fp);
 		}
 		catch (std::exception const &e)
 		{
-			fclose(fp);
+			if (fp != stdout)
+				fclose(fp);
 			throw;
 		}
 	}
@@ -111,7 +115,7 @@ static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInf
 {
 	if (options->encoding != "rgb")
 		throw std::runtime_error("encoding should be set to rgb");
-	FILE *fp = fopen(filename.c_str(), "w");
+	FILE *fp = filename == "-" ? stdout : fopen(filename.c_str(), "w");
 	if (!fp)
 		throw std::runtime_error("failed to open file " + filename);
 	try
@@ -122,11 +126,13 @@ static void rgb_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInf
 			if (fwrite(ptr, 3 * info.width, 1, fp) != 1)
 				throw std::runtime_error("failed to write file " + filename);
 		}
-		fclose(fp);
+		if (fp != stdout)
+			fclose(fp);
 	}
 	catch (std::exception const &e)
 	{
-		fclose(fp);
+		if (fp != stdout)
+			fclose(fp);
 		throw;
 	}
 }


### PR DESCRIPTION
The other save modes have the option of setting a '-' path to redirect to stdout the YUV does not.
This normalizes the behavior 