### PR TITLE
Add libcamera autofocus options

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -382,8 +382,6 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 	StreamConfiguration &cfg = configuration_->at(0);
 	cfg.pixelFormat = libcamera::formats::YUV420;
 	cfg.bufferCount = 6; // 6 buffers is better than 4
-	if (options_->buffer_count > 0) // give option to the user to use a different value
-		cfg.bufferCount = options_->buffer_count;
 	if (options_->width)
 		cfg.size.width = options_->width;
 	if (options_->height)
@@ -487,7 +485,6 @@ void LibcameraApp::StartCamera()
 		controls_.set(controls::ScalerCrop, crop);
 	}
 
-
 	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) && options_->afWindow_width != 0 && options_->afWindow_height != 0)
 	{
 		Rectangle sensor_area = *camera_->properties().get(properties::ScalerCropMaximum);
@@ -547,13 +544,8 @@ void LibcameraApp::StartCamera()
 
 	if(camera_->controls().count(&controls::AfMode)>0){
 		LOG(2, "Camera has AfMode");
-		if (options_->afMode_index!=-1 && !controls_.get(controls::AfMode)){
+		if (options_->afMode_index!=-1 && !controls_.get(controls::AfMode))
 			controls_.set(controls::AfMode, options_->afMode_index);
-			if(options_->afMode_index == controls::AfModeAuto){
-				//does the first focus on start 
-				controls_.set(controls::AfTrigger, controls::AfTriggerStart);
-			}
-		}
 		if (options_->afRange_index!=-1 && !controls_.get(controls::AfRange))
 			controls_.set(controls::AfRange, options_->afRange_index);
 		if (options_->afSpeed_index!=-1 && !controls_.get(controls::AfSpeed))

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -485,7 +485,8 @@ void LibcameraApp::StartCamera()
 		controls_.set(controls::ScalerCrop, crop);
 	}
 
-	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) && options_->afWindow_width != 0 && options_->afWindow_height != 0)
+	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) && options_->afWindow_width != 0 &&
+		options_->afWindow_height != 0)
 	{
 		Rectangle sensor_area = *camera_->properties().get(properties::ScalerCropMaximum);
 		int x = options_->afWindow_x * sensor_area.width;
@@ -493,7 +494,7 @@ void LibcameraApp::StartCamera()
 		int w = options_->afWindow_width * sensor_area.width;
 		int h = options_->afWindow_height * sensor_area.height;
 		Rectangle afwindows_rectangle[1];
-		afwindows_rectangle[0]= Rectangle(x, y, w, h);
+		afwindows_rectangle[0] = Rectangle(x, y, w, h);
 		afwindows_rectangle[0].translateBy(sensor_area.topLeft());
 		LOG(2, "Using AfWindow " << afwindows_rectangle[0].toString());
 		//activate the AfMeteringWindows
@@ -542,13 +543,14 @@ void LibcameraApp::StartCamera()
 	if (!controls_.get(controls::Sharpness))
 		controls_.set(controls::Sharpness, options_->sharpness);
 
-	if(camera_->controls().count(&controls::AfMode)>0){
+	if (camera_->controls().count(&controls::AfMode) > 0)
+	{
 		LOG(2, "Camera has AfMode");
-		if (options_->afMode_index!=-1 && !controls_.get(controls::AfMode))
+		if (options_->afMode_index != -1 && !controls_.get(controls::AfMode))
 			controls_.set(controls::AfMode, options_->afMode_index);
-		if (options_->afRange_index!=-1 && !controls_.get(controls::AfRange))
+		if (options_->afRange_index != -1 && !controls_.get(controls::AfRange))
 			controls_.set(controls::AfRange, options_->afRange_index);
-		if (options_->afSpeed_index!=-1 && !controls_.get(controls::AfSpeed))
+		if (options_->afSpeed_index != -1 && !controls_.get(controls::AfSpeed))
 			controls_.set(controls::AfSpeed, options_->afSpeed_index);
 	}
 	if (camera_->start(&controls_))

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -186,6 +186,9 @@ bool Options::Parse(int argc, char *argv[])
 	if (sscanf(roi.c_str(), "%f,%f,%f,%f", &roi_x, &roi_y, &roi_width, &roi_height) != 4)
 		roi_x = roi_y = roi_width = roi_height = 0; // don't set digital zoom
 
+	if (sscanf(afWindow.c_str(), "%f,%f,%f,%f", &afWindow_x, &afWindow_y, &afWindow_width, &afWindow_height) != 4)
+		afWindow_x = afWindow_y = afWindow_width = afWindow_height = 0; // don't set auto focus windows
+
 	std::map<std::string, int> metering_table =
 		{ { "centre", libcamera::controls::MeteringCentreWeighted },
 			{ "spot", libcamera::controls::MeteringSpot },
@@ -205,6 +208,30 @@ bool Options::Parse(int argc, char *argv[])
 	if (exposure_table.count(exposure) == 0)
 		throw std::runtime_error("Invalid exposure mode:" + exposure);
 	exposure_index = exposure_table[exposure];
+
+	std::map<std::string, int> afMode_table =
+		{ { "manual", libcamera::controls::AfModeManual },
+			{ "auto", libcamera::controls::AfModeAuto },
+			{ "continuous", libcamera::controls::AfModeContinuous } };
+	if (afMode_table.count(afMode) == 0)
+		throw std::runtime_error("Invalid AfMode:" + afMode);
+	afMode_index = afMode_table[afMode];
+
+	std::map<std::string, int> afRange_table =
+		{ { "normal", libcamera::controls::AfRangeNormal },
+			{ "macro", libcamera::controls::AfRangeMacro },
+			{ "full", libcamera::controls::AfRangeFull } };
+	if (afRange_table.count(afRange) == 0)
+		throw std::runtime_error("Invalid AfRange mode:" + exposure);
+	afRange_index = afRange_table[afRange];
+
+
+	std::map<std::string, int> afSpeed_table =
+		{ { "normal", libcamera::controls::AfSpeedNormal },
+		    { "fast", libcamera::controls::AfSpeedFast } };
+	if (afSpeed_table.count(afSpeed) == 0)
+		throw std::runtime_error("Invalid afSpeed mode:" + afSpeed);
+	afSpeed_index = afSpeed_table[afSpeed];
 
 	std::map<std::string, int> awb_table =
 		{ { "auto", libcamera::controls::AwbAuto },
@@ -298,6 +325,14 @@ void Options::Print() const
 	std::cerr << "    lores-width: " << lores_width << std::endl;
 	std::cerr << "    lores-height: " << lores_height << std::endl;
 
+	std::cerr << "    autofocus-mode: " << afMode << std::endl;
+	std::cerr << "    autofocus-range: " << afRange << std::endl;
+	std::cerr << "    autofocus-speed: " << afSpeed << std::endl;
+	if (afWindow_width == 0 || afWindow_height == 0)
+		std::cerr << "    autofocus-window: all" << std::endl;
+	else
+		std::cerr << "    autofocus-window: " << afWindow_x << "," << afWindow_y << "," << afWindow_width << "," << afWindow_height << std::endl;
+	std::cerr << "    lens-position: " << lens_position << std::endl;
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
 	std::cerr << "    metadata: " << metadata << std::endl;

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -327,16 +327,17 @@ void Options::Print() const
 	std::cerr << "    tuning-file: " << (tuning_file == "-" ? "(libcamera)" : tuning_file) << std::endl;
 	std::cerr << "    lores-width: " << lores_width << std::endl;
 	std::cerr << "    lores-height: " << lores_height << std::endl;
-	if(afMode_index != -1)
+	if (afMode_index != -1)
 		std::cerr << "    autofocus-mode: " << afMode << std::endl;
-	if(afRange_index != -1)
-	std::cerr << "    autofocus-range: " << afRange << std::endl;
-	if(afSpeed_index != -1)
-	std::cerr << "    autofocus-speed: " << afSpeed << std::endl;
+	if (afRange_index != -1)
+		std::cerr << "    autofocus-range: " << afRange << std::endl;
+	if (afSpeed_index != -1)
+		std::cerr << "    autofocus-speed: " << afSpeed << std::endl;
 	if (afWindow_width == 0 || afWindow_height == 0)
 		std::cerr << "    autofocus-window: all" << std::endl;
 	else
-		std::cerr << "    autofocus-window: " << afWindow_x << "," << afWindow_y << "," << afWindow_width << "," << afWindow_height << std::endl;
+		std::cerr << "    autofocus-window: " << afWindow_x << "," << afWindow_y << "," << afWindow_width << ","
+				<< afWindow_height << std::endl;
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
 	std::cerr << "    metadata: " << metadata << std::endl;

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -210,7 +210,8 @@ bool Options::Parse(int argc, char *argv[])
 	exposure_index = exposure_table[exposure];
 
 	std::map<std::string, int> afMode_table =
-		{ { "manual", libcamera::controls::AfModeManual },
+		{ { "unset", -1 },
+			{ "manual", libcamera::controls::AfModeManual },
 			{ "auto", libcamera::controls::AfModeAuto },
 			{ "continuous", libcamera::controls::AfModeContinuous } };
 	if (afMode_table.count(afMode) == 0)
@@ -218,7 +219,8 @@ bool Options::Parse(int argc, char *argv[])
 	afMode_index = afMode_table[afMode];
 
 	std::map<std::string, int> afRange_table =
-		{ { "normal", libcamera::controls::AfRangeNormal },
+		{ { "unset", -1 },
+		    { "normal", libcamera::controls::AfRangeNormal },
 			{ "macro", libcamera::controls::AfRangeMacro },
 			{ "full", libcamera::controls::AfRangeFull } };
 	if (afRange_table.count(afRange) == 0)
@@ -227,7 +229,8 @@ bool Options::Parse(int argc, char *argv[])
 
 
 	std::map<std::string, int> afSpeed_table =
-		{ { "normal", libcamera::controls::AfSpeedNormal },
+		{ { "unset", -1 },
+		    { "normal", libcamera::controls::AfSpeedNormal },
 		    { "fast", libcamera::controls::AfSpeedFast } };
 	if (afSpeed_table.count(afSpeed) == 0)
 		throw std::runtime_error("Invalid afSpeed mode:" + afSpeed);
@@ -324,15 +327,16 @@ void Options::Print() const
 	std::cerr << "    tuning-file: " << (tuning_file == "-" ? "(libcamera)" : tuning_file) << std::endl;
 	std::cerr << "    lores-width: " << lores_width << std::endl;
 	std::cerr << "    lores-height: " << lores_height << std::endl;
-
-	std::cerr << "    autofocus-mode: " << afMode << std::endl;
+	if(afMode_index != -1)
+		std::cerr << "    autofocus-mode: " << afMode << std::endl;
+	if(afRange_index != -1)
 	std::cerr << "    autofocus-range: " << afRange << std::endl;
+	if(afSpeed_index != -1)
 	std::cerr << "    autofocus-speed: " << afSpeed << std::endl;
 	if (afWindow_width == 0 || afWindow_height == 0)
 		std::cerr << "    autofocus-window: all" << std::endl;
 	else
 		std::cerr << "    autofocus-window: " << afWindow_x << "," << afWindow_y << "," << afWindow_width << "," << afWindow_height << std::endl;
-	std::cerr << "    lens-position: " << lens_position << std::endl;
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
 	std::cerr << "    metadata: " << metadata << std::endl;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -133,17 +133,15 @@ struct Options
 			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
-			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "override bufferCount config (0 use imlp default)")
-			("autofocus-mode", value<std::string>(&afMode)->default_value("manual"),
-			 " Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
-			("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
+			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "overwrite bufferCount config (0 to use default)")
+			("autofocus-mode", value<std::string>(&afMode)->default_value("unset"),
+			 "Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
+			("autofocus-range", value<std::string>(&afRange)->default_value("unset"),
 			 "Set the range of focus distances that is scanned.(normal, macro, full)")
-			("autofocus-speed", value<std::string>(&afSpeed)->default_value("normal"),
+			("autofocus-speed", value<std::string>(&afSpeed)->default_value("unset"),
 			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
 			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"), 
 			"Sets AfMetering to  AfMeteringWindows an set region used for examle  e.g. 0.25,0.25,0.5,0.5")
-			("lens-position", value<float>(&lens_position)->default_value(0),
-			 "Acts as a control to instruct the lens to move to a particular position and also reports back the position of the lens for each frame. (0 moves the lens to infinity;0.5 moves the lens to twice the hyperfocal distance;1 moves the lens to the hyperfocal position )")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
@@ -190,7 +188,6 @@ struct Options
 	float contrast;
 	float saturation;
 	float sharpness;
-	float lens_position;
 	std::optional<float> framerate;
 	std::string denoise;
 	std::string info_text;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -133,6 +133,17 @@ struct Options
 			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
+			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "override bufferCount config (0 use imlp default)")
+			("autofocus-mode", value<std::string>(&afMode)->default_value("manual"),
+			 " Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
+			("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
+			 "Set the range of focus distances that is scanned.(normal, macro, full)")
+			("autofocus-speed", value<std::string>(&afSpeed)->default_value("normal"),
+			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
+			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"), 
+			"Sets AfMetering to  AfMeteringWindows an set region used for examle  e.g. 0.25,0.25,0.5,0.5")
+			("lens-position", value<float>(&lens_position)->default_value(0),
+			 "Acts as a control to instruct the lens to move to a particular position and also reports back the position of the lens for each frame. (0 moves the lens to infinity;0.5 moves the lens to twice the hyperfocal distance;1 moves the lens to the hyperfocal position )")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
@@ -179,6 +190,7 @@ struct Options
 	float contrast;
 	float saturation;
 	float sharpness;
+	float lens_position;
 	std::optional<float> framerate;
 	std::string denoise;
 	std::string info_text;
@@ -193,8 +205,18 @@ struct Options
 	Mode mode;
 	std::string viewfinder_mode_string;
 	Mode viewfinder_mode;
+	std::string afMode;
+	int afMode_index;
+	unsigned int buffer_count;
+	std::string afRange;
+	int afRange_index;
+	std::string afSpeed;
+	int afSpeed_index;
+	std::string afWindow;
+	float afWindow_x, afWindow_y, afWindow_width, afWindow_height;
 	std::string metadata;
 	std::string metadata_format;
+	
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -210,8 +210,7 @@ struct Options
 	std::string afWindow;
 	float afWindow_x, afWindow_y, afWindow_width, afWindow_height;
 	std::string metadata;
-	std::string metadata_format;
-	
+	std::string metadata_format;	
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -139,7 +139,7 @@ struct Options
 			 "Set the range of focus distances that is scanned.(normal, macro, full)")
 			("autofocus-speed", value<std::string>(&afSpeed)->default_value("unset"),
 			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
-			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"), 
+			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"),
 			"Sets AfMetering to  AfMeteringWindows an set region used for examle  e.g. 0.25,0.25,0.5,0.5")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -210,7 +210,7 @@ struct Options
 	std::string afWindow;
 	float afWindow_x, afWindow_y, afWindow_width, afWindow_height;
 	std::string metadata;
-	std::string metadata_format;	
+	std::string metadata_format;
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -133,7 +133,6 @@ struct Options
 			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
-			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "overwrite bufferCount config (0 to use default)")
 			("autofocus-mode", value<std::string>(&afMode)->default_value("unset"),
 			 "Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
 			("autofocus-range", value<std::string>(&afRange)->default_value("unset"),
@@ -204,7 +203,6 @@ struct Options
 	Mode viewfinder_mode;
 	std::string afMode;
 	int afMode_index;
-	unsigned int buffer_count;
 	std::string afRange;
 	int afRange_index;
 	std::string afSpeed;


### PR DESCRIPTION
Libcamera has some controls options for focus that are useful for some new cameras that exists. 
Arducam 16Mp and 64Mp cameras with autofocus are examples of this. 

This commit add some of this options for focus to the command line.