### PR TITLE
Option to define buffer count overwrite

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -381,7 +381,8 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 	// Now we get to override any of the default settings from the options_->
 	StreamConfiguration &cfg = configuration_->at(0);
 	cfg.pixelFormat = libcamera::formats::YUV420;
-	cfg.bufferCount = 6; // 6 buffers is better than 4
+	if (options_->buffer_count > 0)
+		cfg.bufferCount = options_->buffer_count;
 	if (options_->width)
 		cfg.size.width = options_->width;
 	if (options_->height)
@@ -419,7 +420,9 @@ void LibcameraApp::ConfigureVideo(unsigned int flags)
 			throw std::runtime_error("Low res image larger than video");
 		configuration_->at(lores_index).pixelFormat = libcamera::formats::YUV420;
 		configuration_->at(lores_index).size = lores_size;
-		configuration_->at(lores_index).bufferCount = configuration_->at(0).bufferCount;
+		if(options_->viewfinder_buffer_count > 0)
+			configuration_->at(lores_index).bufferCount = options_->viewfinder_buffer_count;
+		
 	}
 	configuration_->transform = options_->transform;
 

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -300,6 +300,10 @@ void Options::Print() const
 
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
+	if(buffer_count > 0)
+		std::cerr << "    buffer-count: " << buffer_count << std::endl;
+	if(viewfinder_buffer_count > 0)
+		std::cerr << "    viewfinder-buffer-count: " << viewfinder_buffer_count << std::endl;
 	std::cerr << "    metadata: " << metadata << std::endl;
 	std::cerr << "    metadata-format: " << metadata_format << std::endl;
 }

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -133,6 +133,8 @@ struct Options
 			 "Camera mode as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("viewfinder-mode", value<std::string>(&viewfinder_mode_string),
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
+			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "overwrite bufferCount config from libcamera for video; raw and still (0 to use default provided by the libcamera implementation)")
+			("viewfinder-buffer-count", value<unsigned int>(&viewfinder_buffer_count)->default_value(0), "overwrite bufferCount config from libcamera  for the preview (0 to use default provided by the libcamera implementation)")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
@@ -193,6 +195,8 @@ struct Options
 	Mode mode;
 	std::string viewfinder_mode_string;
 	Mode viewfinder_mode;
+	unsigned int buffer_count;
+	unsigned int viewfinder_buffer_count;
 	std::string metadata;
 	std::string metadata_format;
 


### PR DESCRIPTION
Currently libcamera-apps overwrites the bufferCount configuration supplied by the libcamera implementation with a fix value of six.
This alteration removes the harcode overwrites of the value by configuration options on the command line.

To keep current behavior we can change the default configuration from 0 to 6 (the previous hardcoded value) but I think this value should not be overwritten by default, the value return by the implementation of the libcamerra for the current camera device should be always the default in my opinion.