### PR TITLE
core: LibcameraApp::SetControls has a "merge" option, true by default

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -730,10 +730,15 @@ void LibcameraApp::ShowPreview(CompletedRequestPtr &completed_request, Stream *s
 	preview_cond_var_.notify_one();
 }
 
-void LibcameraApp::SetControls(ControlList &controls)
+void LibcameraApp::SetControls(const ControlList &controls)
 {
 	std::lock_guard<std::mutex> lock(control_mutex_);
-	controls_ = std::move(controls);
+
+	// Add new controls to the stored list. If a control is duplicated,
+	// the value in the argument replaces the previously stored value.
+	// These controls will be applied to the next StartCamera or request.
+	for (const auto &c : controls)
+		controls_.set(c.first, c.second);
 }
 
 StreamInfo LibcameraApp::GetStreamInfo(Stream const *stream) const

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -121,7 +121,7 @@ public:
 
 	void ShowPreview(CompletedRequestPtr &completed_request, Stream *stream);
 
-	void SetControls(ControlList &controls);
+	void SetControls(const ControlList &controls);
 	StreamInfo GetStreamInfo(Stream const *stream) const;
 
 	static unsigned int verbosity;


### PR DESCRIPTION
This allows new controls to be added to the stored list rather than replacing it. As before, the argument is invalidated.

Signed-off-by: Nick Hollinghurst <nick.hollinghurst@raspberrypi.com>