### PR TITLE
More autofocus controls

### DIFF
--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -206,6 +206,7 @@ static void event_loop(LibcameraStillApp &app)
 		AF_WAIT_SCANNING,
 		AF_WAIT_FINISHED
 	} af_wait_state = AF_WAIT_NONE;
+	int af_wait_timeout = 0;
 
 	for (unsigned int count = 0;; count++)
 	{
@@ -248,7 +249,7 @@ static void event_loop(LibcameraStillApp &app)
 			{
 				FrameInfo fi(completed_request->metadata);
 				bool scanning = fi.af_state == libcamera::controls::AfStateScanning;
-				if (scanning)
+				if (scanning || (af_wait_state == AF_WAIT_SCANNING && ++af_wait_timeout >= 16))
 					af_wait_state = AF_WAIT_FINISHED;
 				else if (af_wait_state == AF_WAIT_FINISHED)
 					want_capture = true;
@@ -267,6 +268,7 @@ static void event_loop(LibcameraStillApp &app)
 					cl.set(libcamera::controls::AfTrigger, libcamera::controls::AfTriggerStart);
 					app.SetControls(cl);
 					af_wait_state = AF_WAIT_SCANNING;
+					af_wait_timeout = 0;
 				}
 				else
 					want_capture = true;

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -68,6 +68,17 @@ bool Options::Parse(int argc, char *argv[])
 	if (framerate_ != -1.0)
 		framerate = framerate_;
 
+	// lens_position is even more awkward, because we have two "default"
+	// behaviours: Either no lens movement at all (if option is not given),
+	// or libcamera's default control value (typically the hyperfocal).
+	float f = 0.0;
+	if (std::istringstream(lens_position_) >> f)
+		lens_position = f;
+	else if (lens_position_ == "default")
+		set_default_lens_position = true;
+	else if (!lens_position_.empty())
+		throw std::runtime_error("Invalid lens position: " + lens_position_);
+
 	// Set the verbosity
 	LibcameraApp::verbosity = verbose;
 
@@ -338,6 +349,8 @@ void Options::Print() const
 	else
 		std::cerr << "    autofocus-window: " << afWindow_x << "," << afWindow_y << "," << afWindow_width << ","
 				  << afWindow_height << std::endl;
+	if (!lens_position_.empty())
+		std::cerr << "    lens-position: " << lens_position_ << std::endl;
 	std::cerr << "    mode: " << mode.ToString() << std::endl;
 	std::cerr << "    viewfinder-mode: " << viewfinder_mode.ToString() << std::endl;
 	if (buffer_count > 0)

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -39,7 +39,7 @@ struct Mode
 
 struct Options
 {
-	Options() : options_("Valid options are", 120, 80)
+	Options() : set_default_lens_position(false), options_("Valid options are", 120, 80)
 	{
 		using namespace boost::program_options;
 		// clang-format off
@@ -144,6 +144,8 @@ struct Options
 			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
 			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"),
 			"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
+			("lens-position", value<std::string>(&lens_position_)->default_value(""),
+			 "Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
@@ -214,6 +216,8 @@ struct Options
 	int afSpeed_index;
 	std::string afWindow;
 	float afWindow_x, afWindow_y, afWindow_width, afWindow_height;
+	std::optional<float> lens_position;
+	bool set_default_lens_position;
 	std::string metadata;
 	std::string metadata_format;
 
@@ -228,4 +232,5 @@ private:
 	bool vflip_;
 	int rotation_;
 	float framerate_;
+	std::string lens_position_;
 };

--- a/core/still_options.hpp
+++ b/core/still_options.hpp
@@ -46,6 +46,8 @@ struct StillOptions : public Options
 			 "Create a symbolic link with this name to most recent saved file")
 			("immediate", value<bool>(&immediate)->default_value(false)->implicit_value(true),
 			 "Perform first capture immediately, with no preview phase")
+			("autofocus-on-capture", value<bool>(&af_on_capture)->default_value(false)->implicit_value(true),
+			 "Switch to AfModeAuto and trigger a scan just before capturing a still")
 			;
 		// clang-format on
 	}
@@ -65,6 +67,7 @@ struct StillOptions : public Options
 	bool raw;
 	std::string latest;
 	bool immediate;
+	bool af_on_capture;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{
@@ -108,6 +111,7 @@ struct StillOptions : public Options
 		std::cerr << "    thumbnail quality: " << thumb_quality << std::endl;
 		std::cerr << "    latest: " << latest << std::endl;
 		std::cerr << "    immediate " << immediate << std::endl;
+		std::cerr << "    AF on capture: " << af_on_capture << std::endl;
 		for (auto &s : exif)
 			std::cerr << "    EXIF: " << s << std::endl;
 	}


### PR DESCRIPTION
Added the ``--lens-position`` option, based on PR #411 but made optional and with the additional option to use the camera's default value. (The help text is deliberately vague about the units of measurement.)

Added AfTrigger, inferred when AfMode is Auto, but not for stills mode (to avoid moving the lens during capture).

The second commit modifies ``libcamera-still`` to trigger AF and wait for it to complete before capturing each image; the initial viewfinder session is forced to AfModeManual and therefore supports a LensPosition setting.

Frankly, this all seems a bit overwrought and I do wonder if it could be simpler?