### PR TITLE
output: null_encoder: Fix bug in ordering of input/output callbacks

### DIFF
--- a/encoder/null_encoder.cpp
+++ b/encoder/null_encoder.cpp
@@ -57,7 +57,10 @@ void NullEncoder::outputThread()
 					return;
 			}
 		}
-		output_ready_callback_(item.mem, item.length, item.timestamp_us, true);
+		// Ensure the input done callback happens before the output ready callback.
+		// This is needed as the metdata queue gets pushed in the format, and popped
+		// in the latter.
 		input_done_callback_(nullptr);
+		output_ready_callback_(item.mem, item.length, item.timestamp_us, true);
 	}
 }


### PR DESCRIPTION
This would cause a pop from the metadata queue in the output callback before the input callback has a chance to push to the queue.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>