### PR TITLE
options: prevent null pointer access to FrameDurationLimits

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -190,7 +190,7 @@ bool Options::Parse(int argc, char *argv[])
 
 						auto fd_ctrl = cam->controls().find(&controls::FrameDurationLimits);
 						auto crop_ctrl = cam->properties().get(properties::ScalerCropMaximum);
-						double fps = 1e6 / fd_ctrl->second.min().get<int64_t>();
+						double fps = fd_ctrl == cam->controls().end() ? NAN : (1e6 / fd_ctrl->second.min().get<int64_t>());
 						std::cout << std::fixed << std::setprecision(2) << "["
 								  << fps << " fps - " << crop_ctrl->toString() << " crop" << "]";
 						if (--num)


### PR DESCRIPTION
This fixes a null-pointer access when FrameDurationLimits is not available. In this case, the framerate is set to an invalid NAN.