### PR TITLE
core: Tweak default AF options; AfMode now defaults typically to CAF

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -549,16 +549,24 @@ void LibcameraApp::StartCamera()
 	if (!controls_.get(controls::Sharpness))
 		controls_.set(controls::Sharpness, options_->sharpness);
 
-	if (camera_->controls().count(&controls::AfMode) > 0)
+	// AF Controls, where supported and not already set
+	if (!controls_.get(controls::AfMode) && camera_->controls().count(&controls::AfMode) > 0)
 	{
-		LOG(2, "Camera has AfMode");
-		if (options_->afMode_index != -1 && !controls_.get(controls::AfMode))
-			controls_.set(controls::AfMode, options_->afMode_index);
-		if (options_->afRange_index != -1 && !controls_.get(controls::AfRange))
-			controls_.set(controls::AfRange, options_->afRange_index);
-		if (options_->afSpeed_index != -1 && !controls_.get(controls::AfSpeed))
-			controls_.set(controls::AfSpeed, options_->afSpeed_index);
+		int afm = options_->afMode_index;
+		if (afm == -1)
+		{
+			// Choose a default AF mode based on other options
+			if (options_->lens_position || options_->set_default_lens_position || options_->af_on_capture)
+				afm = controls::AfModeManual;
+			else
+				afm = camera_->controls().at(&controls::AfMode).max().get<int>();
+		}
+		controls_.set(controls::AfMode, afm);
 	}
+	if (!controls_.get(controls::AfRange) && camera_->controls().count(&controls::AfRange) > 0)
+		controls_.set(controls::AfRange, options_->afRange_index);
+	if (!controls_.get(controls::AfSpeed) && camera_->controls().count(&controls::AfSpeed) > 0)
+		controls_.set(controls::AfSpeed, options_->afSpeed_index);
 
 	if (controls_.get(controls::AfMode).value_or(controls::AfModeManual) == controls::AfModeAuto)
 	{

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -221,7 +221,7 @@ bool Options::Parse(int argc, char *argv[])
 	exposure_index = exposure_table[exposure];
 
 	std::map<std::string, int> afMode_table =
-		{ { "unset", -1 },
+		{ { "default", -1 },
 			{ "manual", libcamera::controls::AfModeManual },
 			{ "auto", libcamera::controls::AfModeAuto },
 			{ "continuous", libcamera::controls::AfModeContinuous } };
@@ -230,8 +230,7 @@ bool Options::Parse(int argc, char *argv[])
 	afMode_index = afMode_table[afMode];
 
 	std::map<std::string, int> afRange_table =
-		{ { "unset", -1 },
-		    { "normal", libcamera::controls::AfRangeNormal },
+		{ { "normal", libcamera::controls::AfRangeNormal },
 			{ "macro", libcamera::controls::AfRangeMacro },
 			{ "full", libcamera::controls::AfRangeFull } };
 	if (afRange_table.count(afRange) == 0)
@@ -240,8 +239,7 @@ bool Options::Parse(int argc, char *argv[])
 
 
 	std::map<std::string, int> afSpeed_table =
-		{ { "unset", -1 },
-		    { "normal", libcamera::controls::AfSpeedNormal },
+		{ { "normal", libcamera::controls::AfSpeedNormal },
 		    { "fast", libcamera::controls::AfSpeedFast } };
 	if (afSpeed_table.count(afSpeed) == 0)
 		throw std::runtime_error("Invalid afSpeed mode:" + afSpeed);

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -39,7 +39,7 @@ struct Mode
 
 struct Options
 {
-	Options() : set_default_lens_position(false), options_("Valid options are", 120, 80)
+	Options() : set_default_lens_position(false), af_on_capture(false), options_("Valid options are", 120, 80)
 	{
 		using namespace boost::program_options;
 		// clang-format off
@@ -136,11 +136,11 @@ struct Options
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for video, raw, and still.")
 			("viewfinder-buffer-count", value<unsigned int>(&viewfinder_buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for preview window.")
-			("autofocus-mode", value<std::string>(&afMode)->default_value("unset"),
+			("autofocus-mode", value<std::string>(&afMode)->default_value("default"),
 			 "Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
-			("autofocus-range", value<std::string>(&afRange)->default_value("unset"),
+			("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
 			 "Set the range of focus distances that is scanned.(normal, macro, full)")
-			("autofocus-speed", value<std::string>(&afSpeed)->default_value("unset"),
+			("autofocus-speed", value<std::string>(&afSpeed)->default_value("normal"),
 			 "Control that determines whether the AF algorithm is to move the lens as quickly as possible or more steadily.(normal, fast)")
 			("autofocus-window", value<std::string>(&afWindow)->default_value("0,0,0,0"),
 			"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
@@ -218,6 +218,7 @@ struct Options
 	float afWindow_x, afWindow_y, afWindow_width, afWindow_height;
 	std::optional<float> lens_position;
 	bool set_default_lens_position;
+	bool af_on_capture;
 	std::string metadata;
 	std::string metadata_format;
 

--- a/core/still_options.hpp
+++ b/core/still_options.hpp
@@ -67,7 +67,6 @@ struct StillOptions : public Options
 	bool raw;
 	std::string latest;
 	bool immediate;
-	bool af_on_capture;
 
 	virtual bool Parse(int argc, char *argv[]) override
 	{


### PR DESCRIPTION
AF Mode now defaults to the highest supported mode (typically CAF) unless an explicit lens position or af_on_capture was requested. Speed and Range now default to "normal" rather than unset.

Signed-off-by: Nick Hollinghurst <nick.hollinghurst@raspberrypi.com>