### PR TITLE
actions: Switch to v3 scripts

### DIFF
--- a/.github/workflows/libcamera-apps-style-checker.yml
+++ b/.github/workflows/libcamera-apps-style-checker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ self-hosted ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         clean: true

--- a/.github/workflows/libcamera-apps-test.yml
+++ b/.github/workflows/libcamera-apps-test.yml
@@ -22,7 +22,7 @@ jobs:
         build_type: [ Release, Debug ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         clean: true
@@ -41,7 +41,7 @@ jobs:
       run: tar -cvf build-artifacts-${{matrix.compiler}}-${{matrix.build_type}}.tar -C ${{github.workspace}}/build .
 
     - name: Upload build files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-artifacts-${{matrix.compiler}}-${{matrix.build_type}}
         path: build-artifacts-${{matrix.compiler}}-${{matrix.build_type}}.tar
@@ -52,7 +52,7 @@ jobs:
     runs-on: [ self-hosted ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         clean: true
@@ -69,7 +69,7 @@ jobs:
       run: tar -cvf build-artifacts-gcc-lite.tar -C ${{github.workspace}}/build .
 
     - name: Upload build files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-artifacts-gcc-lite
         path: build-artifacts-gcc-lite.tar
@@ -85,7 +85,7 @@ jobs:
         camera: [ imx219, imx477 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         clean: true
@@ -94,7 +94,7 @@ jobs:
       run: mkdir -p ${{github.workspace}}/test_output
 
     - name: Download build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-artifacts-gcc-Release
         path: ${{github.workspace}}
@@ -114,7 +114,7 @@ jobs:
 
     - name: Upload test output
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-artifacts-${{matrix.camera}}
         path: ${{github.workspace}}/test_output/

--- a/.github/workflows/libcamera-test.yml
+++ b/.github/workflows/libcamera-test.yml
@@ -42,7 +42,7 @@ jobs:
       run: tar -cvf build-artifacts-libcamera.tar -C ${{env.LIBCAMERA_SRC_DIR}} .
 
     - name: Upload build files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-artifacts-libcamera
         path: build-artifacts-libcamera.tar
@@ -54,7 +54,7 @@ jobs:
     needs: build-libcamera
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         clean: true
@@ -63,7 +63,7 @@ jobs:
       run: rm -rf ${{env.LIBCAMERA_SRC_DIR}} && mkdir -p ${{env.LIBCAMERA_SRC_DIR}}
 
     - name: Download libcamera artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-artifacts-libcamera
         path: ${{github.workspace}}
@@ -83,7 +83,7 @@ jobs:
       run: tar -cvf build-artifacts-libcamera-apps.tar -C ${{github.workspace}}/build .
 
     - name: Upload build files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build-artifacts-libcamera-apps
         path: build-artifacts-libcamera-apps.tar
@@ -99,7 +99,7 @@ jobs:
         camera: [ imx219, imx477 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         clean: true
@@ -108,7 +108,7 @@ jobs:
       run: mkdir -p ${{github.workspace}}/test_output
 
     - name: Download libcamera-apps build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-artifacts-libcamera-apps
         path: ${{github.workspace}}
@@ -120,7 +120,7 @@ jobs:
       run: rm -rf ${{env.LIBCAMERA_SRC_DIR}} && mkdir -p ${{env.LIBCAMERA_SRC_DIR}}
 
     - name: Download libcamera artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-artifacts-libcamera
         path: ${{github.workspace}}
@@ -140,7 +140,7 @@ jobs:
 
     - name: Upload test output
       if: ${{failure()}}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-artifacts-${{matrix.camera}}
         path: ${{github.workspace}}/test_output/
@@ -163,7 +163,7 @@ jobs:
       run: rm -rf ${{env.LIBCAMERA_SRC_DIR}} && mkdir -p ${{env.LIBCAMERA_SRC_DIR}}
 
     - name: Download libcamera artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build-artifacts-libcamera
         path: ${{github.workspace}}


### PR DESCRIPTION
The v2 checkout/upload-artifact/download-artifact scripts are now deprecated,
switch to the v3 versions.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
