### PR TITLE
build: Set a SONAME version in the libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(libcamera-apps)
+project(libcamera-apps VERSION 1.1.0)
 
 if (NOT EXISTS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
     if (NOT CMAKE_BUILD_TYPE)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -10,7 +10,7 @@ set_source_files_properties(version.cpp PROPERTIES GENERATED 1)
 add_library(libcamera_app libcamera_app.cpp post_processor.cpp version.cpp options.cpp)
 add_dependencies(libcamera_app VersionCpp)
 
-set_target_properties(libcamera_app PROPERTIES PREFIX "" IMPORT_PREFIX "")
+set_target_properties(libcamera_app PROPERTIES PREFIX "" IMPORT_PREFIX "" VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_link_libraries(libcamera_app pthread preview ${LIBCAMERA_LINK_LIBRARIES} ${Boost_LIBRARIES} post_processing_stages)
 
 install(TARGETS libcamera_app LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/encoder/CMakeLists.txt
+++ b/encoder/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
 endif()
 
 add_library(encoders ${SRC})
+set_target_properties(encoders PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_link_libraries(encoders ${TARGET_LIBS})
 target_compile_definitions(encoders PUBLIC LIBAV_PRESENT=${LIBAV_PRESENT})
 

--- a/image/CMakeLists.txt
+++ b/image/CMakeLists.txt
@@ -8,6 +8,7 @@ find_library(TIFF_LIBRARY tiff REQUIRED)
 find_library(PNG_LIBRARY png REQUIRED)
 
 add_library(images bmp.cpp yuv.cpp jpeg.cpp png.cpp dng.cpp)
+set_target_properties(images PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_link_libraries(images jpeg exif png tiff)
 
 install(TARGETS images LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/output/CMakeLists.txt
+++ b/output/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.6)
 include(GNUInstallDirs)
 
 add_library(outputs output.cpp file_output.cpp net_output.cpp circular_output.cpp)
+set_target_properties(outputs PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 
 install(TARGETS outputs LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/post_processing_stages/CMakeLists.txt
+++ b/post_processing_stages/CMakeLists.txt
@@ -49,6 +49,7 @@ else()
 endif()
 
 add_library(post_processing_stages ${SRC})
+set_target_properties(post_processing_stages PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_link_libraries(post_processing_stages ${TARGET_LIBS})
 target_compile_definitions(post_processing_stages PUBLIC OPENCV_PRESENT=${OpenCV_FOUND})
 

--- a/preview/CMakeLists.txt
+++ b/preview/CMakeLists.txt
@@ -64,6 +64,7 @@ else()
 endif()
 
 add_library(preview null_preview.cpp ${SRC})
+set_target_properties(preview PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
 target_link_libraries(preview ${TARGET_LIBS})
 
 target_compile_definitions(preview PUBLIC LIBDRM_PRESENT=${DRM_FOUND})


### PR DESCRIPTION
The libraries built are currently unversioned, but donwstream users expect these to have a proper SONAME version in order to package them. Most Linux distributions packaging guidelines for example have this as a requirement.

There are alredy released versions and git tags, so let's use those as the libraries version, and the major number as the SONAME version. This is the convention used by most projects.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>