### PR TITLE
image: Add Subject Distance to EXIF data, to encode Lens Position

### DIFF
--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -5,6 +5,7 @@
  * dng.cpp - Save raw image as DNG file.
  */
 
+#include <limits>
 #include <map>
 
 #include <libcamera/control_ids.h>
@@ -313,6 +314,13 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 
 		TIFFSetField(tif, EXIFTAG_ISOSPEEDRATINGS, 1, &iso);
 		TIFFSetField(tif, EXIFTAG_EXPOSURETIME, exp_time);
+
+		auto lp = metadata.get(libcamera::controls::LensPosition);
+		if (lp)
+		{
+			double dist = (*lp > 0.0) ? (1.0 / *lp) : std::numeric_limits<double>::infinity();
+			TIFFSetField(tif, EXIFTAG_SUBJECTDISTANCE, dist);
+		}
 
 		TIFFCheckpointDirectory(tif);
 		offset_exififd = TIFFCurrentDirOffset(tif);

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -488,6 +488,13 @@ static void create_exif_data(std::vector<libcamera::Span<uint8_t>> const &mem,
 			LOG(2, "Ag " << *ag << " Dg " << *dg << " Total " << gain);
 			exif_set_short(entry->data, exif_byte_order, 100 * gain);
 		}
+		auto lp = metadata.get(libcamera::controls::LensPosition);
+		if (lp)
+		{
+			entry = exif_create_tag(exif, EXIF_IFD_EXIF, EXIF_TAG_SUBJECT_DISTANCE);
+			ExifRational dist = { 1000, (ExifLong)(1000.0 * *lp) };
+			exif_set_rational(entry->data, exif_byte_order, dist);
+		}
 
 		// Command-line supplied tags.
 		for (auto &exif_item : options->exif)


### PR DESCRIPTION
This is the only bit of AF metadata that seems to match a standard Exif tag. [XXX Because of numerical/API differences, the JPEG and DNG versions can encode slightly different values.]

Signed-off-by: Nick Hollinghurst <nick.hollinghurst@raspberrypi.com>