### PR TITLE
core: Allow info-text to display on the console

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -82,6 +82,11 @@ bool Options::Parse(int argc, char *argv[])
 	if (framerate_ != -1.0)
 		framerate = framerate_;
 
+	// Check if --nopreview is set, and if no info-text string was provided
+	// null the defaulted string so nothing gets displayed to stderr.
+	if (nopreview && vm["info-text"].defaulted())
+		info_text = "";
+
 	// lens_position is even more awkward, because we have two "default"
 	// behaviours: Either no lens movement at all (if option is not given),
 	// or libcamera's default control value (typically the hyperfocal).

--- a/preview/null_preview.cpp
+++ b/preview/null_preview.cpp
@@ -25,6 +25,8 @@ public:
 	// Return the maximum image size allowed. Zeroes mean "no limit".
 	virtual void MaxImageSize(unsigned int &w, unsigned int &h) const override { w = h = 0; }
 
+	void SetInfoText(const std::string &text) override { LOG(1, text); }
+
 private:
 };
 


### PR DESCRIPTION
This will only work if --info-text is explicitly provided in a command
line argument and not defaulted, and --nopreview has been set.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
