### PR TITLE
core: pass VIDIOC_QUERYCAP as unsigned long

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -30,7 +30,9 @@ static void check_camera_stack()
 		return;
 
 	v4l2_capability caps;
-	int ret = ioctl(fd, VIDIOC_QUERYCAP, &caps);
+	unsigned long request = VIDIOC_QUERYCAP;
+
+	int ret = ioctl(fd, request, &caps);
 	close(fd);
 
 	if (ret < 0 || strcmp((char *)caps.driver, "bm2835 mmal"))


### PR DESCRIPTION
VIDIOC_QUARYCAP is an unsigned long and should be passed as one.

Get rid of the following error:
core/libcamera_app.cpp:33:22: error: overflow in conversion from 'long unsigned int' to 'int' changes value from '2154321408' to '-2140645888' [-Werror=overflow]
   33 |  int ret = ioctl(fd, VIDIOC_QUERYCAP, &caps);

Signed-off-by: Marcus Folkesson <marcus.folkesson@gmail.com>