### PR TITLE
image: Exif "Model" tags should store camera model, not ID

### DIFF
--- a/apps/libcamera_detect.cpp
+++ b/apps/libcamera_detect.cpp
@@ -127,7 +127,7 @@ static void event_loop(LibcameraDetectApp &app)
 			filename[sizeof(filename) - 1] = 0;
 			options->framestart++;
 			LOG(1, "Save image " << filename);
-			jpeg_save(mem, info, completed_request->metadata, std::string(filename), app.CameraId(), options);
+			jpeg_save(mem, info, completed_request->metadata, std::string(filename), app.CameraModel(), options);
 
 			// Restart camera in preview mode.
 			app.Teardown();

--- a/apps/libcamera_jpeg.cpp
+++ b/apps/libcamera_jpeg.cpp
@@ -82,7 +82,7 @@ static void event_loop(LibcameraJpegApp &app)
 			StreamInfo info = app.GetStreamInfo(stream);
 			CompletedRequestPtr &payload = std::get<CompletedRequestPtr>(msg.payload);
 			const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(payload->buffers[stream]);
-			jpeg_save(mem, info, payload->metadata, options->output, app.CameraId(), options);
+			jpeg_save(mem, info, payload->metadata, options->output, app.CameraModel(), options);
 			return;
 		}
 	}

--- a/apps/libcamera_still.cpp
+++ b/apps/libcamera_still.cpp
@@ -81,9 +81,9 @@ static void save_image(LibcameraStillApp &app, CompletedRequestPtr &payload, Str
 	StreamInfo info = app.GetStreamInfo(stream);
 	const std::vector<libcamera::Span<uint8_t>> mem = app.Mmap(payload->buffers[stream]);
 	if (stream == app.RawStream())
-		dng_save(mem, info, payload->metadata, filename, app.CameraId(), options);
+		dng_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "jpg")
-		jpeg_save(mem, info, payload->metadata, filename, app.CameraId(), options);
+		jpeg_save(mem, info, payload->metadata, filename, app.CameraModel(), options);
 	else if (options->encoding == "png")
 		png_save(mem, info, filename, options);
 	else if (options->encoding == "bmp")

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -87,6 +87,12 @@ std::string const &LibcameraApp::CameraId() const
 	return camera_->id();
 }
 
+std::string LibcameraApp::CameraModel() const
+{
+	auto model = camera_->properties().get(properties::Model);
+	return model ? *model : camera_->id();
+}
+
 void LibcameraApp::OpenCamera()
 {
 	// Make a preview window.

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -95,6 +95,7 @@ public:
 	Options *GetOptions() const { return options_.get(); }
 
 	std::string const &CameraId() const;
+	std::string CameraModel() const;
 	void OpenCamera();
 	void CloseCamera();
 

--- a/image/dng.cpp
+++ b/image/dng.cpp
@@ -16,6 +16,10 @@
 #include "core/still_options.hpp"
 #include "core/stream_info.hpp"
 
+#ifndef MAKE_STRING
+#define MAKE_STRING "Raspberry Pi"
+#endif
+
 using namespace libcamera;
 
 static char TIFF_RGGB[4] = { 0, 1, 1, 2 };
@@ -127,9 +131,8 @@ Matrix(float m0, float m1, float m2,
 	}
 };
 
-void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const &info,
-			  ControlList const &metadata, std::string const &filename,
-			  std::string const &cam_name, StillOptions const *options)
+void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const &info, ControlList const &metadata,
+			  std::string const &filename, std::string const &cam_model, StillOptions const *options)
 {
 	// Check the Bayer format and unpack it to u16.
 
@@ -225,6 +228,7 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		const short cfa_repeat_pattern_dim[] = { 2, 2 };
 		uint32_t white = (1 << bayer_format.bits) - 1;
 		toff_t offset_subifd = 0, offset_exififd = 0;
+		std::string unique_model = std::string(MAKE_STRING " ") + cam_model;
 
 		tif = TIFFOpen(filename.c_str(), "w");
 		if (!tif)
@@ -238,11 +242,11 @@ void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 		TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, 8);
 		TIFFSetField(tif, TIFFTAG_COMPRESSION, COMPRESSION_NONE);
 		TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, PHOTOMETRIC_RGB);
-		TIFFSetField(tif, TIFFTAG_MAKE, "Raspberry Pi");
-		TIFFSetField(tif, TIFFTAG_MODEL, cam_name.c_str());
+		TIFFSetField(tif, TIFFTAG_MAKE, MAKE_STRING);
+		TIFFSetField(tif, TIFFTAG_MODEL, cam_model.c_str());
 		TIFFSetField(tif, TIFFTAG_DNGVERSION, "\001\001\000\000");
 		TIFFSetField(tif, TIFFTAG_DNGBACKWARDVERSION, "\001\000\000\000");
-		TIFFSetField(tif, TIFFTAG_UNIQUECAMERAMODEL, cam_name.c_str());
+		TIFFSetField(tif, TIFFTAG_UNIQUECAMERAMODEL, unique_model.c_str());
 		TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
 		TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, 3);
 		TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);

--- a/image/image.hpp
+++ b/image/image.hpp
@@ -19,7 +19,7 @@ struct StillOptions;
 
 // In jpeg.cpp:
 void jpeg_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const &info,
-			   libcamera::ControlList const &metadata, std::string const &filename, std::string const &cam_name,
+			   libcamera::ControlList const &metadata, std::string const &filename, std::string const &cam_model,
 			   StillOptions const *options);
 
 // In yuv.cpp:
@@ -28,7 +28,7 @@ void yuv_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const
 
 // In dng.cpp:
 void dng_save(std::vector<libcamera::Span<uint8_t>> const &mem, StreamInfo const &info,
-			  libcamera::ControlList const &metadata, std::string const &filename, std::string const &cam_name,
+			  libcamera::ControlList const &metadata, std::string const &filename, std::string const &cam_model,
 			  StillOptions const *options);
 
 // In png.cpp:

--- a/post_processing_stages/hdr_stage.cpp
+++ b/post_processing_stages/hdr_stage.cpp
@@ -491,7 +491,7 @@ bool HdrStage::Process(CompletedRequestPtr &completed_request)
 		filename[sizeof(filename) - 1] = 0;
 		StillOptions const *options = dynamic_cast<StillOptions *>(app_->GetOptions());
 		if (options)
-			jpeg_save(buffers, info_, completed_request->metadata, filename, app_->CameraId(), options);
+			jpeg_save(buffers, info_, completed_request->metadata, filename, app_->CameraModel(), options);
 		else
 			LOG(1, "No still options - unable to save JPEG");
 	}


### PR DESCRIPTION
It seems to be more in the spirit of the Exif and DNG specs to record the camera's "model" string, rather than its ID (which is neither a model nor a unique serial number), and to prefix a "Make" onto UniqueCameraModel.

The Make ("Raspberry Pi") is now a `#define` so that it can be overridden by Makefiles, but I'm happy to rework this.

Before:
```
Make                            : Raspberry Pi
Camera Model Name               : /base/soc/i2c0mux/i2c@1/imx708@1a
Unique Camera Model             : /base/soc/i2c0mux/i2c@1/imx708@1a
```

After:
```
Make                            : Raspberry Pi
Camera Model Name               : imx708_wide
Unique Camera Model             : Raspberry Pi imx708_wide
```

Here are some possible reasons why we might _not_ want this change:
- It changes behaviour that users may already be relying on
- In a multi-camera setup (e.g. CM4), the camera's ID is no longer recorded
- It might change again if we change the way we handle variants (cameras with the same sensor)
- It misleadingly suggests that Raspberry Pi is the manufacturer of the named sensors, rather than OmniVision or Sony
- Libcamera's "Model" property "is not guaranteed to be stable or have any other properties required to make it a good candidate to be used as a permanent identifier of a camera."
