### PR TITLE
preview: Fix QtPreview for preview width not a multiple of 4

### DIFF
--- a/preview/qt_preview.cpp
+++ b/preview/qt_preview.cpp
@@ -92,7 +92,6 @@ public:
 		uint8_t *Y_start = span.data();
 		uint8_t *U_start = Y_start + info.stride * info.height;
 		int uv_size = (info.stride / 2) * (info.height / 2);
-		uint8_t *dest = pane_->image.bits();
 
 		// Choose the right matrix to convert YUV back to RGB.
 		static const float YUV2RGB[3][9] = {
@@ -120,6 +119,7 @@ public:
 			uint8_t *Y_row = Y_start + row * info.stride;
 			uint8_t *U_row = U_start + (row / 2) * (info.stride / 2);
 			uint8_t *V_row = U_row + uv_size;
+			uint8_t *dest = pane_->image.scanLine(y);
 			for (unsigned int x = 0; x < window_width_;)
 			{
 				int y_off0 = x_locations_[x++];


### PR DESCRIPTION
Fix for #447.

The fix is required because QImage always pads each scanline to align to a 4-byte boundary. The simplest way to cope with this is to just call `QImage::scanLine(y)` for each line of output.

This is a simpler case than in Picamera2, as we do a conversion into the image rather than creating it with existing data -- no need to re-pack data in memory or make any advance assumptions about QImage alignment.