### PR TITLE
encoder: H264: Trap framerate=0 to avoid division by zero error

### DIFF
--- a/encoder/h264_encoder.cpp
+++ b/encoder/h264_encoder.cpp
@@ -131,12 +131,16 @@ H264Encoder::H264Encoder(VideoOptions const *options, StreamInfo const &info)
 	if (xioctl(fd_, VIDIOC_S_FMT, &fmt) < 0)
 		throw std::runtime_error("failed to set capture format");
 
-	struct v4l2_streamparm parm = {};
-	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
-	parm.parm.output.timeperframe.numerator = 1000 / options->framerate.value_or(DEFAULT_FRAMERATE);
-	parm.parm.output.timeperframe.denominator = 1000;
-	if (xioctl(fd_, VIDIOC_S_PARM, &parm) < 0)
-		throw std::runtime_error("failed to set streamparm");
+	double frate = options->framerate.value_or(DEFAULT_FRAMERATE);
+	if (frate > 0.0)
+	{
+		struct v4l2_streamparm parm = {};
+		parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+		parm.parm.output.timeperframe.numerator = 90000.0 / frate;
+		parm.parm.output.timeperframe.denominator = 90000;
+		if (xioctl(fd_, VIDIOC_S_PARM, &parm) < 0)
+			throw std::runtime_error("failed to set streamparm");
+	}
 
 	// Request that the necessary buffers are allocated. The output queue
 	// (input to the encoder) shares buffers from our caller, these must be


### PR DESCRIPTION
Without this change, `libcamera-vid -t 0 --framerate 0` would typically lock up after a few hundred frames.

Also, I've increased the denominator to 90kHz so that rates such as 30fps, 29.97fps can be represented accurately.