### PR TITLE
image: Fix missing fclose

### DIFF
--- a/image/yuv.cpp
+++ b/image/yuv.cpp
@@ -44,6 +44,8 @@ static void yuv420_save(std::vector<libcamera::Span<uint8_t>> const &mem, Stream
 				if (fwrite(V + j * stride, w, 1, fp) != 1)
 					throw std::runtime_error("failed to write file " + filename);
 			}
+			if (fp != stdout)
+				fclose(fp);
 		}
 		catch (std::exception const &e)
 		{


### PR DESCRIPTION
The success path through yuv420_save does not close the file.  Fix this.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
