### PR TITLE
utils: Update the timestamp script to work with container files

### DIFF
--- a/utils/timestamp.py
+++ b/utils/timestamp.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021, Raspberry Pi Ltd.
 #
 import argparse
+import subprocess
 
 try:
     from matplotlib import pyplot as plt
@@ -12,10 +13,21 @@ except ImportError:
     plot_available = False
 
 
-def read_times(file):
+def read_times_pts(file):
     with open(file) as f:
-        f.readline()  # there's one header line we must skip
+        if f.readline() != '# timecode format v2':
+            raise RuntimeError('PTS file format unknown')
         return [float(line) for line in f.readlines()]
+
+
+def read_times_container(file):
+    cmd = ['ffprobe', file, '-hide_banner', '-select_streams', 'v', '-show_entries', 'frame=pkt_pts_time', '-of', 'csv=p=0']
+    r = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+    if r.returncode:
+        raise RuntimeError(f'ffprobe failed to run with command:\n{" ".join(cmd)}')
+
+    ts_list = [float(ts) * 1000 for ts in r.stdout.split('\n')[1:-1]]
+    return ts_list
 
 
 def get_differences(items):
@@ -44,17 +56,26 @@ def plot_pts(diffs, avg, title):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='libcamera-apps timestamp analysis tool')
-    parser.add_argument('filename', help='PTS file generated from libcamera-vid', type=str)
+    parser.add_argument('filename', help='PTS file generated from libcamera-vid (with a .txt or .pts extension)'
+                                         ' or an avi/mkv/mp4 container file', type=str)
     parser.add_argument('--plot', help='Plot timestamp graph', action='store_true')
     args = parser.parse_args()
 
-    times = read_times(args.filename)
+    if args.filename.lower().endswith(('.txt', '.pts')):
+        times = read_times_pts(args.filename)
+    elif args.filename.lower().endswith(('.avi', '.mkv', '.mp4')):
+        times = read_times_container(args.filename)
+    else:
+        raise RuntimeError('Unknown file format')
+
     diffs = get_differences(times)
     avg = sum(diffs) / len(diffs)
     min_val, min_idx = min((val, idx) for (idx, val) in enumerate(diffs))
     max_val, max_idx = max((val, idx) for (idx, val) in enumerate(diffs))
-    print(f'Minimum: {min_val:.3f} ms at frame {min_idx}\nMaximum: {max_val:.3f} ms at frame {max_idx}\nAverage: {avg:.3f} ms')
-    print(f'Total: {len(diffs)} samples')
+    print(f'Total: {len(diffs) + 1} frames ({len(diffs)} samples)')
+    print(f'Average: {avg:.3f} ms / {1e3/avg:.3f} fps')
+    print(f'Minimum: {min_val:.3f} ms at frame {min_idx}')
+    print(f'Maximum: {max_val:.3f} ms at frame {max_idx}')
     print('Outliers:', *[outliers(diffs, f, avg) for f in (1, .1, .01, .001)])
 
     if args.plot:


### PR DESCRIPTION
Use ffprobe to read video timestamp information from mkv/mp4/avi
container files.

Slight formatting update to the output.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
