### PR TITLE
core: Add header guard in libcamera_encoder.hpp

### DIFF
--- a/core/libcamera_encoder.hpp
+++ b/core/libcamera_encoder.hpp
@@ -5,6 +5,8 @@
  * libcamera_encoder.cpp - libcamera video encoding class.
  */
 
+#pragma once
+
 #include "core/libcamera_app.hpp"
 #include "core/stream_info.hpp"
 #include "core/video_options.hpp"


### PR DESCRIPTION
Need a missing #pragma once in this header file.

Signed-off-by: Naushir Patuck <naush@raspberrypi.com>
