### PR TITLE
Add option --audio-channels.

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -76,6 +76,8 @@ struct VideoOptions : public Options
 			 "\"pactl list | grep -A2 'Source #' | grep 'Name: '\"\n"
 			 "or for alsa, use the following command:\n"
 			 "\"arecord -L\"")
+			("audio-channels", value<uint32_t>(&audio_channels)->default_value(0),
+			 "Number of channels to use for recording audio. Set to 0 to use default value.")
 			("audio-bitrate", value<uint32_t>(&audio_bitrate)->default_value(32768),
 			 "Set the audio bitrate for encoding, in bits/second.")
 			("audio-samplerate", value<uint32_t>(&audio_samplerate)->default_value(0),
@@ -99,6 +101,7 @@ struct VideoOptions : public Options
 	std::string audio_codec;
 	std::string audio_device;
 	std::string audio_source;
+	uint32_t audio_channels;
 	uint32_t audio_bitrate;
 	uint32_t audio_samplerate;
 	int32_t av_sync;

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -146,9 +146,21 @@ void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo cons
 #endif
 
 	assert(in_fmt_ctx_ == nullptr);
-	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);
+
+	int ret;
+	AVDictionary *format_opts = nullptr;
+
+	if (options->audio_channels != 0)
+		ret = av_dict_set_int(&format_opts, "channels", options->audio_channels, 0);
+
+	ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, &format_opts);
 	if (ret < 0)
+	{
+		av_dict_free(&format_opts);
 		throw std::runtime_error("libav: cannot open " + options->audio_source + " input device " + options->audio_device);
+	}
+
+	av_dict_free(&format_opts);
 
 	avformat_find_stream_info(in_fmt_ctx_, nullptr);
 

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -148,7 +148,7 @@ void LibAvEncoder::initAudioInCodec(VideoOptions const *options, StreamInfo cons
 	assert(in_fmt_ctx_ == nullptr);
 	int ret = avformat_open_input(&in_fmt_ctx_, options->audio_device.c_str(), input_fmt, nullptr);
 	if (ret < 0)
-		throw std::runtime_error("libav: cannot open pulseaudio input device " + options->audio_device);
+		throw std::runtime_error("libav: cannot open " + options->audio_source + " input device " + options->audio_device);
 
 	avformat_find_stream_info(in_fmt_ctx_, nullptr);
 


### PR DESCRIPTION
When recording audio using ALSA from a mono mic (attached to an USB
soundcard in my case), you get an error message like this:

_[alsa @ 0x5555638680] cannot set channel count to 2 (Invalid argument)_

When using Pulse, it works, but it's a waste of space on your microSD,
USB stick, USB HDD/SDD, network drive or whatever.

This commit implements an option that has the same effect as ffmpeg's
-ac option.