### PR TITLE
core: options: Sort cameras for consistency

### DIFF
--- a/.github/workflows/libcamera-test.yml
+++ b/.github/workflows/libcamera-test.yml
@@ -172,7 +172,7 @@ jobs:
       run: tar -xvf build-artifacts-libcamera.tar -C ${{env.LIBCAMERA_SRC_DIR}}
 
     - name: Setup meson
-      run: cd ${{env.LIBCAMERA_SRC_DIR}} && meson build --reconfigure -Dprefix=${{env.LIBCAMERA_LKG_DIR}} -Dpipelines=raspberrypi -Dtest=false
+      run: cd ${{env.LIBCAMERA_SRC_DIR}} && meson build --reconfigure -Dprefix=${{env.LIBCAMERA_LKG_DIR}} -Dpipelines=rpi/vc4 -Dtest=false
 
     - name: Build
       run: cd ${{env.LIBCAMERA_SRC_DIR}}/build && ninja install

--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -108,12 +108,7 @@ void LibcameraApp::OpenCamera()
 	if (ret)
 		throw std::runtime_error("camera manager failed to start, code " + std::to_string(-ret));
 
-	std::vector<std::shared_ptr<libcamera::Camera>> cameras = camera_manager_->cameras();
-	// Do not show USB webcams as these are not supported in libcamera-apps!
-	auto rem = std::remove_if(cameras.begin(), cameras.end(),
-							  [](auto &cam) { return cam->id().find("/usb") != std::string::npos; });
-	cameras.erase(rem, cameras.end());
-
+	std::vector<std::shared_ptr<libcamera::Camera>> cameras = LibcameraApp::GetCameras(camera_manager_);
 	if (cameras.size() == 0)
 		throw std::runtime_error("no cameras available");
 	if (options_->camera >= cameras.size())

--- a/core/libcamera_app.hpp
+++ b/core/libcamera_app.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <thread>
 #include <variant>
+#include <vector>
 
 #include <libcamera/base/span.h>
 #include <libcamera/camera.h>
@@ -127,6 +128,17 @@ public:
 
 	static unsigned int verbosity;
 	static unsigned int GetVerbosity() { return verbosity; }
+
+	static std::vector<std::shared_ptr<libcamera::Camera>> GetCameras(const std::unique_ptr<CameraManager> &cm)
+	{
+		std::vector<std::shared_ptr<libcamera::Camera>> cameras = cm->cameras();
+		// Do not show USB webcams as these are not supported in libcamera-apps!
+		auto rem = std::remove_if(cameras.begin(), cameras.end(),
+								  [](auto &cam) { return cam->id().find("/usb") != std::string::npos; });
+		cameras.erase(rem, cameras.end());
+		std::sort(cameras.begin(), cameras.end(), [](auto l, auto r) { return l->id() > r->id(); });
+		return cameras;
+	}
 
 protected:
 	std::unique_ptr<Options> options_;

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -153,12 +153,7 @@ bool Options::Parse(int argc, char *argv[])
 		if (ret)
 			throw std::runtime_error("camera manager failed to start, code " + std::to_string(-ret));
 
-		std::vector<std::shared_ptr<libcamera::Camera>> cameras = cm->cameras();
-		// Do not show USB webcams as these are not supported in libcamera-apps!
-		auto rem = std::remove_if(cameras.begin(), cameras.end(),
-								  [](auto &cam) { return cam->id().find("/usb") != std::string::npos; });
-		cameras.erase(rem, cameras.end());
-
+		std::vector<std::shared_ptr<libcamera::Camera>> cameras = LibcameraApp::GetCameras(cm);
 		if (cameras.size() != 0)
 		{
 			unsigned int idx = 0;


### PR DESCRIPTION
Move the camera listing functionality into a single static function. Sort the camera list vector so that the camera numbers presented to the user are always consistent, regardless of the device enumeration order in the kernel.