### PR TITLE
output: Ensure we flush before closing a file

### DIFF
--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -67,7 +67,12 @@ void FileOutput::openFile(int64_t timestamp_us)
 
 void FileOutput::closeFile()
 {
-	if (fp_ && fp_ != stdout)
-		fclose(fp_);
-	fp_ = nullptr;
+	if (fp_)
+	{
+		if (options_->flush)
+			fflush(fp_);
+		if (fp_ != stdout)
+			fclose(fp_);
+		fp_ = nullptr;
+	}
 }


### PR DESCRIPTION
Flush the file output before closing if the --flush flag is set.