### PR TITLE
encoder: New LibAV segment, split and pause implementation

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -116,8 +116,8 @@ struct VideoOptions : public Options
 			 "Use 'pause' to pause the recording at startup, otherwise 'record' (the default)")
 			("split", value<bool>(&split)->default_value(false)->implicit_value(true),
 			 "Create a new output file every time recording is paused and then resumed")
-			("segment", value<uint32_t>(&segment)->default_value(0),
-			 "Break the recording into files of approximately this many milliseconds")
+			("segment", value<std::string>(&segment_)->default_value("0ms"),
+			 "Break the recording into files of approximately this duration (in milliseconds if no units provided)")
 			("circular", value<size_t>(&circular)->default_value(0)->implicit_value(4),
 			 "Write output to a circular buffer of the given size (in MB) which is saved on exit")
 			("frames", value<unsigned int>(&frames)->default_value(0),
@@ -181,7 +181,7 @@ struct VideoOptions : public Options
 	std::string initial;
 	bool pause;
 	bool split;
-	uint32_t segment;
+	TimeVal<std::chrono::milliseconds> segment;
 	size_t circular;
 	uint32_t frames;
 
@@ -193,6 +193,7 @@ struct VideoOptions : public Options
 		av_sync.set(av_sync_);
 		bitrate.set(bitrate_);
 		audio_bitrate.set(audio_bitrate_);
+		segment.set(segment_);
 
 		if (width == 0)
 			width = 640;
@@ -244,7 +245,7 @@ struct VideoOptions : public Options
 		std::cerr << "    signal: " << signal << std::endl;
 		std::cerr << "    initial: " << initial << std::endl;
 		std::cerr << "    split: " << split << std::endl;
-		std::cerr << "    segment: " << segment << std::endl;
+		std::cerr << "    segment: " << segment.get() << "ms" << std::endl;
 		std::cerr << "    circular: " << circular << std::endl;
 	}
 
@@ -252,4 +253,5 @@ private:
 	std::string av_sync_;
 	std::string bitrate_;
 	std::string audio_bitrate_;
+	std::string segment_;
 };

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -65,7 +65,22 @@ const std::map<std::string, std::function<void(VideoOptions const *, AVCodecCont
 
 void LibAvEncoder::Signal()
 {
-	feed_encoder_frames_ = !feed_encoder_frames_;
+	// We now need to tell the rest of the program what is happening
+	pause_state_.paused = !pause_state_.paused;
+	if (pause_state_.first_pause)
+		pause_state_.first_pause = false;
+	// When we switch from paused to not paused, update the timestamp at which that happened
+	if (!pause_state_.paused)
+	{
+		segment_start_ts_ = current_timestamp_;
+		pause_state_.unpause_timestamp = current_timestamp_ - pause_state_.pause_duration - video_start_ts_;
+	}
+	// Unpaused to Pause means that we have paused. Similarly update timestamps following
+	if (pause_state_.paused)
+	{
+		pause_state_.pause_timestamp = current_timestamp_ - pause_state_.pause_duration - video_start_ts_;
+		pause_state_.unpause_timestamp = 0;
+	}
 }
 
 void LibAvEncoder::initVideoCodec(VideoOptions const *options, StreamInfo const &info)
@@ -279,8 +294,7 @@ void LibAvEncoder::initAudioOutCodec(VideoOptions const *options, StreamInfo con
 LibAvEncoder::LibAvEncoder(VideoOptions const *options, StreamInfo const &info)
 	: Encoder(options), output_ready_(false), abort_video_(false), abort_audio_(false), video_start_ts_(0),
 	  audio_samples_(0), in_fmt_ctx_(nullptr), out_fmt_ctx_(nullptr), segment_start_ts_(0), segment_num_(0),
-	  virtual_video_ts_(0), virtual_audio_ts_(0), previous_video_timestamp_(0), previous_audio_timestamp_(0),
-	  feed_encoder_frames_(true), previous_feed_value_(true)
+	  previous_video_timestamp_(0), current_timestamp_(0)
 {
 	avdevice_register_all();
 
@@ -339,14 +353,12 @@ void LibAvEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const
 	{
 		video_start_ts_ = timestamp_us;
 		segment_start_ts_ = video_start_ts_;
+		pause_state_.pause_timestamp = 0;
+		pause_state_.unpause_timestamp = 0;
 	}
-	// Segmentation Function
-	if ((options_->segment && (timestamp_us - segment_start_ts_) / 1000 > options_->segment) && output_ready_)
-		nextSegment(timestamp_us, segment_start_ts_);
-	// Split Function
-	//want to catch the 'rising edge' of the feed_frames variable. when it rises, we want to save the file and start with a new one
-	if (options_->split && previous_feed_value_ != feed_encoder_frames_ && feed_encoder_frames_)
-		nextSegment(timestamp_us, virtual_video_ts_);
+	current_timestamp_ = timestamp_us + (options_->av_sync.value < 0us
+											 ? -options_->av_sync.get<std::chrono::microseconds>()
+											 : 0); // Standard Recording modes
 
 	frame->format = codec_ctx_[Video]->pix_fmt;
 	frame->width = info.width;
@@ -356,21 +368,7 @@ void LibAvEncoder::EncodeBuffer(int fd, size_t size, void *mem, StreamInfo const
 	if (previous_video_timestamp_ == 0)
 		previous_video_timestamp_ = timestamp_us; // Only useful on startup
 
-	int64_t elapsed_time = timestamp_us - previous_video_timestamp_; // Time since last loop. Needed for pause function
-
-	if (feed_encoder_frames_ && options_->keypress)
-	{
-		// If feeding video and keypress option is on, then count the frame timer for the frames
-		virtual_video_ts_ += elapsed_time;
-		frame->pts = virtual_video_ts_; // Gives the frames a relative time since recording started
-	}
-	else
-	{
-		frame->pts = timestamp_us - video_start_ts_ +
-				(options_->av_sync.value < 0us ? -options_->av_sync.get<std::chrono::microseconds>() : 0); // Standard Recording modes
-	}
-	previous_video_timestamp_ = timestamp_us;
-	previous_feed_value_ = feed_encoder_frames_;
+	frame->pts = current_timestamp_ - video_start_ts_;
 
 	if (codec_ctx_[Video]->pix_fmt == AV_PIX_FMT_DRM_PRIME)
 	{
@@ -499,27 +497,36 @@ void LibAvEncoder::encode(AVPacket *pkt, unsigned int stream_id)
 		// Rescale from the codec timebase to the stream timebase.
 		av_packet_rescale_ts(pkt, codec_ctx_[stream_id]->time_base, out_fmt_ctx_->streams[stream_id]->time_base);
 
+		// When we are paused, keep track of how long passes in the pause state. Needed to make video continuous
+		if (!pause_state_.write_frames)
+			pause_state_.pause_duration += current_timestamp_ - previous_video_timestamp_;
+		previous_video_timestamp_ = current_timestamp_;
 		std::scoped_lock<std::mutex> lock(output_mutex_);
-		// pkt is now blank (av_interleaved_write_frame() takes ownership of
-		// its contents and resets pkt), so that no unreferencing is necessary.
-		// This would be different if one used av_write_frame().
-		ret = av_interleaved_write_frame(out_fmt_ctx_, pkt);
-		if (ret < 0)
-			throw std::runtime_error("libav: error writing output: " + std::to_string(ret));
+
+		if (options_->keypress || options_->signal)
+			writePausedFrame(pkt, stream_id);
+
+		if (options_->segment)
+			writeSegmentedFrame(pkt, stream_id);
+
+		// This is normal operation, with now pause/segment functionalit
+		if (!options_->segment && !options_->keypress && !options_->signal)
+			ret = writeFrame(out_fmt_ctx_, pkt);
+
+		// Only update pause_state_ variables on video feed
+		if (stream_id == Video)
+			pause_state_.previous_state = pause_state_.paused;
 	}
 }
 
-void LibAvEncoder::nextSegment(int64_t timestamp_us, int64_t &update_variable)
+void LibAvEncoder::nextSegment()
 {
-	// Prevent threads from writing to file whilst being shut down and reopened
-	std::scoped_lock<std::mutex> lock(output_mutex_);
 	// Flush the encoder, finish segment, save file
-	segment_num_ += 1;
 	deinitOutput();
 	// Now, start up again
+	segment_num_ += 1;
+	pause_state_.first_frame = true;
 	initOutput();
-	// Update the timestamps so that the videos are timestamped correctly
-	update_variable = timestamp_us;
 }
 
 extern "C" void LibAvEncoder::releaseBuffer(void *opaque, uint8_t *data)
@@ -561,18 +568,28 @@ void LibAvEncoder::videoThread()
 					video_cv_.wait_for(lock, 200ms);
 			}
 		}
-		if (feed_encoder_frames_)
+
+		// We force a keyframe when we detect that the state of pause has gone from PAUSED -> UNPAUSED (1) -> (0)
+		if (pause_state_.previous_state && !pause_state_.paused)
 		{
-			// Needed for pause functionality
-			int ret = avcodec_send_frame(codec_ctx_[Video], frame);
-			if (ret < 0)
-			{
-				char err[256];
-				av_strerror(ret, err, sizeof(err));
-				throw std::runtime_error(std::string("libav: error encoding frame: ") + std::string(err));
-			}
-			encode(pkt, Video);
+			// We have just unpaused. Need to force keyframe
+			frame->pict_type = AV_PICTURE_TYPE_I;
 		}
+		if ((current_timestamp_ - segment_start_ts_) > options_->segment.get<std::chrono::microseconds>() &&
+			!pause_state_.first_frame)
+		{
+			// Time to segment! We now need to force a keyframe for the encode thread to create a new segment with
+			frame->pict_type = AV_PICTURE_TYPE_I;
+		}
+
+		int ret = avcodec_send_frame(codec_ctx_[Video], frame);
+		if (ret < 0)
+		{
+			char err[256];
+			av_strerror(ret, err, sizeof(err));
+			throw std::runtime_error(std::string("libav: error encoding frame: ") + std::string(err));
+		}
+		encode(pkt, Video);
 		av_frame_free(&frame);
 	}
 
@@ -723,31 +740,14 @@ void LibAvEncoder::audioThread()
 			AVRational num = { 1, out_frame->sample_rate };
 			int64_t ts = av_rescale_q(audio_samples_, num, codec_ctx_[AudioOut]->time_base);
 
-			// Need to set up timestamps based on the video recording settings:
-			if (previous_audio_timestamp_ == 0)
-				previous_audio_timestamp_ = ts; // Only useful on startup
+			out_frame->pts =
+				ts + (options_->av_sync.value > 0us ? options_->av_sync.get<std::chrono::microseconds>() : 0);
 
-			int64_t et = ts - previous_audio_timestamp_; // Elapsed Time
-
-			if (feed_encoder_frames_ && options_->keypress)
-			{
-				// If feeding audio and keypress option is on, then count the frame timer for the audio frames
-				virtual_audio_ts_ += et;
-				out_frame->pts = virtual_audio_ts_;
-			}
-			else
-				out_frame->pts = ts - virtual_audio_ts_ +
-						(options_->av_sync.value > 0us ? options_->av_sync.get<std::chrono::microseconds>() : 0);
-
-			previous_audio_timestamp_ = ts; // Previous TimeStamp
 			audio_samples_ += codec_ctx_[AudioOut]->frame_size;
-			if (feed_encoder_frames_)
-			{
-				ret = avcodec_send_frame(codec_ctx_[AudioOut], out_frame);
-				if (ret < 0)
-					throw std::runtime_error("libav: error encoding frame: " + std::to_string(ret));
-				encode(out_pkt, AudioOut);
-			}
+
+			ret = avcodec_send_frame(codec_ctx_[AudioOut], out_frame);
+			if (ret < 0)
+				throw std::runtime_error("libav: error encoding frame: " + std::to_string(ret));
 			av_frame_free(&out_frame);
 		}
 	}
@@ -763,4 +763,87 @@ void LibAvEncoder::audioThread()
 	av_packet_free(&in_pkt);
 	av_packet_free(&out_pkt);
 	av_frame_free(&in_frame);
+}
+
+int LibAvEncoder::writeFrame(AVFormatContext *out_fmt_ctx_, AVPacket *pkt)
+{
+	// Handler to write frame
+	int ret = 0;
+	ret = av_interleaved_write_frame(out_fmt_ctx_, pkt);
+	if (ret < 0)
+		throw std::runtime_error("libav: error writing output: " + std::to_string(ret));
+	return ret;
+}
+
+int LibAvEncoder::writePausedFrame(AVPacket *pkt, unsigned int stream_id)
+{
+	// Need to detect what state the packet came from
+	// If the timestamp is after a pause timestamp and before an unpause ts then it must be paused, and hence thrown away
+	// Additionally, the timestamp can be after a pause event but the current unpause timestamp is equal to zero, and hence is also paused
+	// if the timestamp is after an unpause timestamp and after the latest pause timestamp then it must be written (unpaused state)
+
+	// In the following, the logic all happens when we are passed a video frame. i.e. starting a new segment, initating split.
+	// Audio just follows a through afterwards. This is needed to make sure that the first thing in the video file is a keyframe.
+
+	// Need a constant value to the packet's timestamp
+	int64_t packet_ts = pkt->pts;
+	// Alter the timestamps to be continuous
+	pkt->pts -= pause_state_.pause_duration;
+	pkt->dts -= pause_state_.pause_duration;
+
+	// The below logic works out if a frame is paused. If the packet is after a pause, and the packet is before a pause
+	// or the unpause timestamp is set to zero (which indicates a pause)
+	// This method does mean that we need an extra variable, first pause (since unpause timestamp initialises to zero)
+	// There is likely a better implementation for this
+
+	if (packet_ts > pause_state_.pause_timestamp &&
+		(packet_ts < pause_state_.unpause_timestamp || !pause_state_.unpause_timestamp) && !pause_state_.first_pause)
+	{
+		// This must be a paused frame. We shall discard it
+		if (!pause_state_.first_frame && stream_id == Video)
+		{
+			// Upon pausing, set variables up for next segment, and if we are splitting, call function to create new output
+			pause_state_.first_frame = true;
+			if (options_->split)
+				nextSegment();
+		}
+		pause_state_.write_frames = false;
+		return 1;
+	}
+	if (packet_ts >= pause_state_.unpause_timestamp &&
+		((packet_ts > pause_state_.pause_timestamp && pause_state_.unpause_timestamp != 0) || pause_state_.first_pause))
+	{
+		// This frame fits into the 'unpaused' category
+		if (pause_state_.first_frame && pkt->flags & AV_PKT_FLAG_KEY && stream_id == Video)
+		{
+			// This is the first frame that is a keyframe. This will be the start of a new segment/split.
+			return writeFrame(out_fmt_ctx_, pkt);
+			pause_state_.first_frame = false;
+			pause_state_.write_frames = true;
+		}
+		// If there's nothing special going on, just write the frame
+		else if (!pause_state_.first_frame && pause_state_.write_frames)
+			return writeFrame(out_fmt_ctx_, pkt);
+	}
+	return 1;
+}
+
+int LibAvEncoder::writeSegmentedFrame(AVPacket *pkt, unsigned int stream_id)
+{
+	if ((current_timestamp_ - segment_start_ts_) > options_->segment.get<std::chrono::microseconds>() &&
+		!pause_state_.first_frame && stream_id == Video)
+	{
+		// Over segmenting threshold. Ready to make a new segment.
+		nextSegment();
+	}
+	if ((current_timestamp_ - segment_start_ts_) > options_->segment.get<std::chrono::microseconds>() &&
+		pkt->flags & AV_PKT_FLAG_KEY && pause_state_.first_frame && stream_id == Video)
+	{
+		// This is the first keyframe that has arrived since the start of a segment
+		pause_state_.first_frame = false;
+		segment_start_ts_ = current_timestamp_;
+		return writeFrame(out_fmt_ctx_, pkt);
+	}
+	else // Again, not much going on here, just write the frame
+		return writeFrame(out_fmt_ctx_, pkt);
 }

--- a/output/file_output.cpp
+++ b/output/file_output.cpp
@@ -24,7 +24,7 @@ void FileOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint
 	// and recording is being restarted (this is necessarily an I-frame already).
 	if (fp_ == nullptr ||
 		(options_->segment && (flags & FLAG_KEYFRAME) &&
-		 timestamp_us / 1000 - file_start_time_ms_ > options_->segment) ||
+		 timestamp_us / 1000 - file_start_time_ms_ > options_->segment.get<std::chrono::microseconds>()) ||
 		(options_->split && (flags & FLAG_RESTART)))
 	{
 		closeFile();


### PR DESCRIPTION
Reprogrammed the implementation of segment, split and pause for when encoding with LibAV. Moved functionality to the encode thread New version should make it easier to implement timestamping and metadata for files.