### PR TITLE
libav: Allow libcamera-vid to run with minimal options using libav

### DIFF
--- a/core/video_options.hpp
+++ b/core/video_options.hpp
@@ -126,7 +126,7 @@ struct VideoOptions : public Options
 			("libav-video-codec", value<std::string>(&libav_video_codec)->default_value("h264_v4l2m2m"),
 			 "Sets the libav video codec to use. "
 			 "To list available codecs, run  the \"ffmpeg -codecs\" command.")
-			("libav-format", value<std::string>(&libav_format)->default_value(""),
+			("libav-format", value<std::string>(&libav_format)->default_value("h264"),
 			 "Sets the libav encoder output format to use. "
 			 "Leave blank to try and deduce this from the filename.\n"
 			 "To list available formats, run  the \"ffmpeg -formats\" command.")

--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -388,7 +388,7 @@ void LibAvEncoder::initOutput()
 	char err[64];
 	if (!(out_fmt_ctx_->flags & AVFMT_NOFILE))
 	{
-		std::string filename = options_->output;
+		std::string filename = options_->output.empty() ? "/dev/null" : options_->output;
 
 		// libav uses "pipe:" for stdout
 		if (filename == "-")


### PR DESCRIPTION
Set a default output file to /dev/null if none has been provided. Set the default container to an elementary stream.