### PR TITLE
core: Use correct pipeline config file for different platforms

### DIFF
--- a/encoder/encoder.cpp
+++ b/encoder/encoder.cpp
@@ -30,6 +30,7 @@ Encoder *h264_codec_select(VideoOptions *options, const StreamInfo &info)
 	if (fd)
 	{
 		int ret = ioctl(fd, VIDIOC_QUERYCAP, &caps);
+		close(fd);
 		if (!ret && !strncmp((char *)caps.card, "bcm2835-codec-encode", sizeof(caps.card)))
 			return new H264Encoder(options, info);
 	}


### PR DESCRIPTION
Update and rename check_camera_stack() to get_platform().  This functions now returns the running platform if known. The pipeline config files are now selected based on the detected platform.

As a drive-by add a missing close(fd) when detecting if the HW encoder is present.