### PR TITLE
core: test: Add a no-raw option

### DIFF
--- a/core/options.hpp
+++ b/core/options.hpp
@@ -189,6 +189,8 @@ struct Options
 			 "Camera mode for preview as W:H:bit-depth:packing, where packing is P (packed) or U (unpacked)")
 			("buffer-count", value<unsigned int>(&buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for video, raw, and still.")
 			("viewfinder-buffer-count", value<unsigned int>(&viewfinder_buffer_count)->default_value(0), "Number of in-flight requests (and buffers) configured for preview window.")
+			("no-raw", value<bool>(&no_raw)->default_value(false)->implicit_value(true),
+			 "Disable requesting of a RAW stream. Will override any manual mode reqest the mode choice when setting framerate.")
 			("autofocus-mode", value<std::string>(&afMode)->default_value("default"),
 			 "Control to set the mode of the AF (autofocus) algorithm.(manual, auto, continuous)")
 			("autofocus-range", value<std::string>(&afRange)->default_value("normal"),
@@ -281,6 +283,7 @@ struct Options
 	std::string metadata_format;
 	bool hdr;
 	TimeVal<std::chrono::microseconds> flicker_period;
+	bool no_raw;
 
 	virtual bool Parse(int argc, char *argv[]);
 	virtual void Print() const;

--- a/utils/test.py
+++ b/utils/test.py
@@ -108,6 +108,12 @@ def test_hello(exe_dir, output_dir):
     check_retcode(retcode, "test_hello: flips test")
     check_time(time_taken, 1.8, 6, "test_hello: flips test")
 
+    # "no-raw". Run without a raw stream
+    print("    no-raw test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '--no-raw'], logfile)
+    check_retcode(retcode, "test_hello: no-raw test")
+    check_time(time_taken, 1.8, 6, "test_hello: no-raw test")
+
     print("libcamera-hello tests passed")
 
 
@@ -187,6 +193,13 @@ def test_still(exe_dir, output_dir):
     check_retcode(retcode, "test_still: jpg test")
     check_time(time_taken, 1.2, 8, "test_still: jpg test")
     check_size(output_jpg, 1024, "test_still: jpg test")
+
+    # "no-raw test". As above but without a raw stream.
+    print("    jpg test")
+    retcode, time_taken = run_executable([executable, '-t', '1000', '-o', output_jpg, '--no-raw'], logfile)
+    check_retcode(retcode, "test_still: no-raw test")
+    check_time(time_taken, 1.2, 8, "test_still: no-raw test")
+    check_size(output_jpg, 1024, "test_still: no-raw test")
 
     # "png test". As above, but write a png.
     print("    png test")
@@ -352,6 +365,14 @@ def test_vid(exe_dir, output_dir):
     check_retcode(retcode, "test_vid: h264 test")
     check_time(time_taken, 2, 6, "test_vid: h264 test")
     check_size(output_h264, 1024, "test_vid: h264 test")
+
+    # "no-raw". As above, but with no raw stream
+    print("    h264 test")
+    retcode, time_taken = run_executable([executable, '-t', '2000', '-o', output_h264, '--no-raw'],
+                                         logfile)
+    check_retcode(retcode, "test_vid: no-raw test")
+    check_time(time_taken, 2, 6, "test_vid: no-raw test")
+    check_size(output_h264, 1024, "test_vid: no-raw test")
 
     # "mjpeg test". As above, but write an mjpeg file.
     print("    mjpeg test")


### PR DESCRIPTION
Add an command line option "--no-raw" to disable raw stream selection entirely. This is mainly useful for testing the pipeline handler code path that would otherwise not be exercised through libcamera-apps.

Update the test scripts to use this flag in the tests.