### PR TITLE
core: Add single exposure PiSP HDR mode

### DIFF
--- a/core/libcamera_app.cpp
+++ b/core/libcamera_app.cpp
@@ -631,6 +631,9 @@ void LibcameraApp::StartCamera()
 		controls_.set(controls::Saturation, options_->saturation);
 	if (!controls_.get(controls::Sharpness))
 		controls_.set(controls::Sharpness, options_->sharpness);
+	if (!controls_.get(controls::HdrMode) &&
+	    (options_->hdr == "auto" || options_->hdr == "single-exp"))
+		controls_.set(controls::HdrMode, controls::HdrModeSingleExposure);
 
 	// AF Controls, where supported and not already set
 	if (!controls_.get(controls::AfMode) && camera_->controls().count(&controls::AfMode) > 0)

--- a/core/options.hpp
+++ b/core/options.hpp
@@ -201,8 +201,10 @@ struct Options
 			"Sets AfMetering to  AfMeteringWindows an set region used, e.g. 0.25,0.25,0.5,0.5")
 			("lens-position", value<std::string>(&lens_position_)->default_value(""),
 			 "Set the lens to a particular focus position, expressed as a reciprocal distance (0 moves the lens to infinity), or \"default\" for the hyperfocal distance")
-			("hdr", value<bool>(&hdr)->default_value(false)->implicit_value(true),
-			 "Enable (1) or disable (0) High Dynamic Range, where supported")
+			("hdr", value<std::string>(&hdr)->default_value("off")->implicit_value("auto"),
+			 "Enable High Dynamic Range, where supported. Available values are \"off\", \"auto\", "
+			 "\"sensor\" for sensor HDR (e.g. for Camera Module 3), "
+			 "\"single-exp\" for PiSP based single exposure multiframe HDR")
 			("metadata", value<std::string>(&metadata),
 			 "Save captured image metadata to a file or \"-\" for stdout")
 			("metadata-format", value<std::string>(&metadata_format)->default_value("json"),
@@ -281,7 +283,7 @@ struct Options
 	bool af_on_capture;
 	std::string metadata;
 	std::string metadata_format;
-	bool hdr;
+	std::string hdr;
 	TimeVal<std::chrono::microseconds> flicker_period;
 	bool no_raw;
 


### PR DESCRIPTION
Update the --hdr option to support the single exposure multi-frame HDR mode available on the PiSP HW. The option can now take the following values:

"off": No HDR
"auto": Automically select the HDR mode, where "sensor" is top priority
"sensor": Sensor HDR (e.g. Camera v3)
"single-exp": Single exposure HDR mode

The implicit value of this argument is "auto".