### PR TITLE
Consider avoiding the use of drm_prime as pixel format

### DIFF
--- a/encoder/libav_encoder.hpp
+++ b/encoder/libav_encoder.hpp
@@ -9,7 +9,6 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <memory>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -71,7 +70,4 @@ private:
 	AVStream *stream_[3];
 	AVFormatContext *in_fmt_ctx_;
 	AVFormatContext *out_fmt_ctx_;
-
-	std::mutex drm_queue_lock_;
-	std::queue<std::unique_ptr<AVDRMFrameDescriptor>> drm_frame_queue_;
 };


### PR DESCRIPTION
To my knowledge the drm_prime pixel format is something required by the stateless HEVC hardware decoder of the Raspberry Pi.
I can't see any benefit or requirement in using it while using the H264 hardware encoder.

Considering this also has the effect of breaking compatibility with mainline libav, would it be possible to avoid its use?