### PR TITLE
Feature/acoustic focus stage

### DIFF
--- a/assets/acoustic_focus.json
+++ b/assets/acoustic_focus.json
@@ -1,0 +1,12 @@
+{
+    "acoustic_focus": {
+        "stage": "acoustic_focus",
+        "minFoM": 1,
+        "maxFoM": 2000,
+        "minFreq": 300,
+        "maxFreq": 5000,
+        "duration": 0.1,
+        "mapping": "log",
+        "description": "mapping values are log (logarithmic) or linear"
+    }
+}

--- a/post_processing_stages/README.md
+++ b/post_processing_stages/README.md
@@ -1,0 +1,162 @@
+## AcousticFocusStage – Documentation (English)
+
+**Purpose:**  
+The AcousticFocusStage is a post-processing stage for rpicam-apps that provides acoustic feedback based on the libcamera Focus Figure of Merit (FoM).  
+This allows you to find the optimal focus point of a manual lens **without needing to look at or interpret the preview image**.
+
+### Features
+
+- Plays a sine tone via the Raspberry Pi’s audio output.
+- The tone’s frequency is mapped to the current Focus FoM value (frequency rises or falls as FoM rises or falls).
+- No visual contact with the preview is required.
+- The tone is triggered once per second for a configurable duration.
+- All parameters (frequency range, mapping type, duration, etc.) can be configured via JSON.
+- **Note:** You must use an external USB sound card, HDMI audio, or another supported audio device for this stage to function.
+
+### Dependencies
+
+Install the following packages:
+
+```sh
+sudo apt update
+sudo apt install sox libsox-fmt-all
+```
+
+### Build Instructions
+
+1. Add `acoustic_focus_stage.cpp` to your `post_processing_stages` directory.
+2. Add the stage to your `meson.build`:
+   ```meson
+   core_postproc_src = files([
+       ...
+       'acoustic_focus_stage.cpp',
+   ])
+   postproc_assets += files([
+       ...
+       assets_dir / 'acoustic_focus.json',
+   ])
+   ```
+3. Rebuild and install:
+   ```sh
+   meson compile -C build
+   sudo meson install -C build
+   ```
+
+### Configuration
+
+Create a config file `acoustic_focus.json` (example):
+
+```json
+{
+  "acoustic_focus": [
+    {
+      "stage": "acoustic_focus",
+      "minFoM": 1,
+      "maxFoM": 2000,
+      "minFreq": 300,
+      "maxFreq": 5000,
+      "duration": 0.1,
+      "mapping": "log",
+      "description": "mapping values are log (logarithmic) or linear"
+    }
+  ]
+}
+```
+
+- `minFoM`, `maxFoM`: Range of Figure of Merit values to map.
+- `minFreq`, `maxFreq`: Frequency range for the output tone (Hz).
+- `duration`: Tone duration in seconds.
+- `mapping`: `"log"` for logarithmic mapping, `"linear"` for linear mapping.
+
+### Usage
+
+1. Start rpicam-vid with:
+   ```sh
+   rpicam-vid --post-process-config assets/acoustic_focus.json
+   ```
+2. Adjust focus on your manual lens. The tone’s pitch will rise or fall as the focus improves or worsens.
+
+---
+
+## AcousticFocusStage – Dokumentation (Deutsch)
+
+**Zweck:**  
+Die AcousticFocusStage ist eine Post-Processing-Stage für rpicam-apps, die akustisches Feedback auf Basis des libcamera Focus Figure of Merit (FoM) gibt.  
+Damit findest du den optimalen Fokuspunkt einer manuellen Linse **ohne auf die Vorschau schauen oder diese interpretieren zu müssen**.
+
+### Funktionen
+
+- Gibt einen Sinuston über den Audio-Ausgang des Raspberry Pi aus.
+- Die Tonhöhe wird aus dem aktuellen Focus FoM-Wert berechnet (steigt oder fällt mit dem FoM).
+- Kein Sichtkontakt zur Vorschau erforderlich.
+- Der Ton wird einmal pro Sekunde für eine konfigurierbare Dauer ausgegeben.
+- Alle Parameter (Frequenzbereich, Mapping-Typ, Dauer usw.) sind per JSON konfigurierbar.
+- **Hinweis:** Es muss eine Soundausgabe-Hardware vorhanden sein.
+
+### Abhängigkeiten
+
+Installiere folgende Pakete:
+
+```sh
+sudo apt update
+sudo apt install sox libsox-fmt-all
+```
+
+### Kompilierung
+
+1. Lege `acoustic_focus_stage.cpp` im Verzeichnis `post_processing_stages` ab.
+2. Ergänze die Stage in deiner `meson.build`:
+   ```meson
+   core_postproc_src = files([
+       ...
+       'acoustic_focus_stage.cpp',
+   ])
+   postproc_assets += files([
+       ...
+       assets_dir / 'acoustic_focus.json',
+   ])
+   ```
+3. Baue und installiere neu:
+   ```sh
+   meson compile -C build
+   sudo meson install -C build
+   ```
+
+### Konfiguration
+
+Beispiel für `acoustic_focus.json`:
+
+```json
+{
+  "acoustic_focus": [
+    {
+      "stage": "acoustic_focus",
+      "minFoM": 1,
+      "maxFoM": 2000,
+      "minFreq": 400,
+      "maxFreq": 2000,
+      "duration": 0.1,
+      "mapping": "log", // oder "linear"
+      "description": "mapping values are log (logarithmic) or linear"
+    }
+  ]
+}
+```
+
+- `minFoM`, `maxFoM`: Bereich der Figure of Merit-Werte.
+- `minFreq`, `maxFreq`: Frequenzbereich für den Ton (Hz).
+- `duration`: Tondauer in Sekunden.
+- `mapping`: `"log"` für logarithmisch, `"linear"` für linear.
+
+### Verwendung
+
+1. Starte rpicam-vid mit:
+   ```sh
+   rpicam-vid --post-process-config assets/acoustic_focus.json
+   ```
+2. Drehe am Fokusring deiner manuellen Linse. Die Tonhöhe steigt oder fällt, je nach Fokusqualität.
+
+---
+
+**Hinweis:**  
+Die Stage ist ein reines Hilfsmittel für das manuelle Fokussieren und benötigt keinen Blickkontakt zum Monitor!

--- a/post_processing_stages/acoustic_focus_stage.cpp
+++ b/post_processing_stages/acoustic_focus_stage.cpp
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (C) 2025, Kletternaut
+ *
+ * acoustic_focus_stage.cpp - acoustic feedback for autofocus FoM
+ *
+ * This stage provides acoustic feedback based on the libcamera Autofocus Figure of Merit (FoM).
+ * The FoM is mapped to an audible frequency, allowing users to hear focus quality changes in real time.
+ * No visual contact with the preview is required, and the preview does not need to be interpreted.
+ * As the FoM rises or falls, the tone frequency also rises or falls accordingly.
+ * Various parameters (e.g. frequency range, mapping type, duration) can be configured via JSON.
+ * Note: Sound output hardware must be present for this stage to function.
+ */
+
+#include <libcamera/controls.h>
+#include "core/rpicam_app.hpp"
+#include "post_processing_stages/post_processing_stage.hpp"
+#include <iostream>
+#include <chrono>
+#include <sstream>
+#include <iomanip>
+#include <thread>
+#include <cmath>
+#include <fstream>
+
+
+class AcousticFocusStage : public PostProcessingStage
+{
+public:
+    AcousticFocusStage(RPiCamApp *app) : PostProcessingStage(app){}
+
+    char const *Name() const override { return "acoustic_focus"; }
+
+    void Read(boost::property_tree::ptree const &params) override
+    {
+        min_fom_ = params.get<int>("minFoM", 1);
+        max_fom_ = params.get<int>("maxFoM", 3000);
+        min_freq_ = params.get<int>("minFreq", 300);
+        max_freq_ = params.get<int>("maxFreq", 3000);
+        duration_ = params.get<double>("duration", 0.1);
+        mapping_ = params.get<std::string>("mapping", "log");
+    }
+
+    bool Process(CompletedRequestPtr &completed_request) override
+    {
+        static auto last = std::chrono::steady_clock::now();
+
+        auto now = std::chrono::steady_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - last).count();
+
+        if (ms >= 1000)
+        {
+            last = now;
+
+            auto fom = completed_request->metadata.get(libcamera::controls::FocusFoM);
+            if (fom)
+            {
+                int freq = min_freq_;
+                if (mapping_ == "log") {
+                    double norm = std::log(std::max(*fom, min_fom_)) - std::log(min_fom_);
+                    double denom = std::log(max_fom_) - std::log(min_fom_);
+                    freq = min_freq_ + static_cast<int>(norm / denom * (max_freq_ - min_freq_));
+                } else { // linear
+                    double norm = std::max(*fom, min_fom_) - min_fom_;
+                    double denom = max_fom_ - min_fom_;
+                    freq = min_freq_ + static_cast<int>(norm / denom * (max_freq_ - min_freq_));
+                }
+                freq = std::min(max_freq_, std::max(min_freq_, freq));
+
+                std::ostringstream oss;
+                oss << std::fixed << std::setprecision(6) << duration_;
+                std::string duration_str = oss.str();
+
+                std::string cmd = "/usr/bin/play -nq -t alsa synth " + duration_str +
+                                  " sine " + std::to_string(freq);
+                std::thread([](std::string cmd) { system(cmd.c_str()); }, cmd).detach();
+            }
+        }
+        return false;
+    }
+
+private:
+    int min_fom_ = 1, max_fom_ = 2000;
+    int min_freq_ = 400, max_freq_ = 2000;
+    double duration_ = 0.1;
+    std::string mapping_ = "log";
+};
+
+static PostProcessingStage *Create(RPiCamApp *app)
+{
+    return new AcousticFocusStage(app);
+}
+static RegisterStage reg("acoustic_focus", &Create);

--- a/post_processing_stages/meson.build
+++ b/post_processing_stages/meson.build
@@ -20,6 +20,7 @@ core_postproc_src = files([
     'hdr_stage.cpp',
     'motion_detect_stage.cpp',
     'negate_stage.cpp',
+    'acoustic_focus_stage.cpp',
 ])
 
 # Core assets
@@ -27,6 +28,7 @@ postproc_assets += files([
     assets_dir / 'hdr.json',
     assets_dir / 'motion_detect.json',
     assets_dir / 'negate.json',
+    assets_dir / 'acoustic_focus.json',
 ])
 
 core_postproc_lib = shared_module('core-postproc', core_postproc_src,


### PR DESCRIPTION
### AcousticFocusStage: Acoustic Feedback for Manual Focusing

**Summary:**  
This pull request introduces a new `AcousticFocusStage` for rpicam-apps. The stage provides real-time acoustic feedback based on the camera’s Focus Figure of Merit (FoM), making it much easier to achieve optimal manual focus - especially when the preview is not visible.

**Key Features:**
- Plays a sine tone whose frequency is mapped to the current FoM value.
- All parameters (frequency range, mapping type, duration, etc.) are configurable via JSON.
- No need to look at the preview—just listen for the highest pitch to find the best focus.
- Includes English and German documentation and a sample configuration file.
- Can also be used as an **acoustic motion detector**: sudden changes in the FoM will be heard as abrupt changes in pitch.

**Why?**  
Manual focusing can be challenging without visual feedback. This stage enables intuitive, hands-free focusing by ear, which is especially useful in field setups or for visually impaired users.

**Notes:**
- Requires a supported audio output device (USB sound card, HDMI audio, etc.).
- Depends on SoX for audio playback (`sox` and `libsox-fmt-all` packages).
