### PR TITLE
core: Add sensor temperature reporting

### DIFF
--- a/core/frame_info.hpp
+++ b/core/frame_info.hpp
@@ -18,7 +18,7 @@ struct FrameInfo
 {
 	FrameInfo(const CompletedRequestPtr &completed_request)
 		: exposure_time(0.0), digital_gain(0.0), colour_gains({ { 0.0f, 0.0f } }), focus(0.0), aelock(false),
-		  lens_position(-1.0), af_state(0)
+		  lens_position(-1.0), af_state(0), sensor_temp(0.0)
 	{
 		const libcamera::ControlList &ctrls = completed_request->metadata;
 
@@ -54,6 +54,10 @@ struct FrameInfo
 		auto lp = ctrls.get(libcamera::controls::LensPosition);
 		if (lp)
 			lens_position = *lp;
+
+		auto temp = ctrls.get(libcamera::controls::SensorTemperature);
+		if (temp)
+			sensor_temp = *temp;
 
 		auto afs = ctrls.get(libcamera::controls::AfState);
 		if (afs)
@@ -92,6 +96,8 @@ struct FrameInfo
 					value << aelock;
 				else if (t == "%lp")
 					value << lens_position;
+				else if (t == "%temp")
+					value << sensor_temp;
 				else if (t == "%afstate")
 				{
 					switch (af_state)
@@ -127,10 +133,12 @@ struct FrameInfo
 	bool aelock;
 	float lens_position;
 	int af_state;
+	float sensor_temp;
 
 private:
 	// Info text tokens.
-	inline static const std::string tokens[] = { "%frame", "%fps", "%exp", "%ag", "%dg",
-						     "%rg", "%bg",  "%focus", "%aelock",
-						     "%lp", "%afstate" };
+	inline static const std::string tokens[] = {
+		"%frame", "%fps", "%exp", "%ag", "%dg", "%rg", "%bg",  "%focus",
+		"%aelock","%lp", "%temp", "%afstate"
+	};
 };

--- a/core/options.cpp
+++ b/core/options.cpp
@@ -210,7 +210,8 @@ Options::Options()
 			"%frame (frame number)\n%fps (framerate)\n%exp (shutter speed)\n%ag (analogue gain)"
 			"\n%dg (digital gain)\n%rg (red colour gain)\n%bg (blue colour gain)"
 			"\n%focus (focus FoM value)\n%aelock (AE locked status)"
-			"\n%lp (lens position, if known)\n%afstate (AF state, if supported)")
+			"\n%lp (lens position, if known)\n%temp (sensor temperature, if available)"
+			"\n%afstate (AF state, if supported)")
 		("width", value<unsigned int>(&width)->default_value(0),
 			"Set the output image width (0 = use default value)")
 		("height", value<unsigned int>(&height)->default_value(0),


### PR DESCRIPTION
The info-text tag %temp can be used to report the sensor temperature if available.