### PR TITLE
core: Hide startup frames

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -1119,6 +1119,10 @@ void RPiCamApp::requestComplete(Request *request)
 		completed_requests_.insert(r);
 	}
 
+	// Framebuffer reports possibly being in a startup or error state, ignore these.
+	if (r->buffers.begin()->second->metadata().status != libcamera::FrameMetadata::FrameSuccess)
+		return;
+
 	// We calculate the instantaneous framerate in case anyone wants it.
 	// Use the sensor timestamp if possible as it ought to be less glitchy than
 	// the buffer timestamps.


### PR DESCRIPTION
Hide frames that are not marked with FrameMetadata::FrameSuccess, as they could be either invalid or startup frames.