### PR TITLE
Fix unused error and DISABLE_RPI_FEATURES

### DIFF
--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -641,7 +641,11 @@ void RPiCamApp::StartCamera()
 
 	// Build a list of initial controls that we must set in the camera before starting it.
 	// We don't overwrite anything the application may have set before calling us.
-	if (!controls_.get(controls::ScalerCrop) && !controls_.get(controls::rpi::ScalerCrops))
+	#ifndef DISABLE_RPI_FEATURES
+	if (!controls_.get(controls::ScalerCrop) && !controls_.get(controls::rpi::ScalerCrops))	
+	#else
+	if (!controls_.get(controls::ScalerCrop))
+	#endif
 	{
 		const Rectangle sensor_area = camera_->controls().at(&controls::ScalerCrop).max().get<Rectangle>();
 		const Rectangle default_crop = camera_->controls().at(&controls::ScalerCrop).def().get<Rectangle>();
@@ -669,10 +673,15 @@ void RPiCamApp::StartCamera()
 			LOG(2, "Using crop (lores) " << crops.back().toString());
 		}
 
+		#ifndef DISABLE_RPI_FEATURES
 		if (options_->GetPlatform() == Platform::VC4)
 			controls_.set(controls::ScalerCrop, crops[0]);
 		else
 			controls_.set(controls::rpi::ScalerCrops, libcamera::Span<const Rectangle>(crops.data(), crops.size()));
+		#else
+		if (options_->GetPlatform() == Platform::VC4)
+			controls_.set(controls::ScalerCrop, crops[0]);
+		#endif
 	}
 
 	if (!controls_.get(controls::AfWindows) && !controls_.get(controls::AfMetering) &&

--- a/core/rpicam_encoder.hpp
+++ b/core/rpicam_encoder.hpp
@@ -99,6 +99,7 @@ private:
 		// pairs.)
 		assert(mem == nullptr);
 		{
+            (void)mem;
 			std::lock_guard<std::mutex> lock(encode_buffer_queue_mutex_);
 			if (encode_buffer_queue_.empty())
 				throw std::runtime_error("no buffer available to return");


### PR DESCRIPTION
This is a fix to make RPICAM-APPS compile on none Raspberry PI systems. Also in INDI (where we have INDI Libcamera driver), we get an error about unused parameter so this is fixed as well. 