### PR TITLE
core: Switch libcamera string controls to use std::string_view

### DIFF
--- a/core/options.cpp
+++ b/core/options.cpp
@@ -418,7 +418,7 @@ bool OptsInternal::Parse(boost::program_options::variables_map &vm, RPiCamApp *a
 	std::vector<std::shared_ptr<libcamera::Camera>> cameras = app->GetCameras();
 	if (camera < cameras.size())
 	{
-		const std::string cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
+		const std::string_view cam_id = *cameras[camera]->properties().get(libcamera::properties::Model);
 
 		if (cam_id.find("imx708") != std::string::npos)
 		{

--- a/core/rpicam_app.cpp
+++ b/core/rpicam_app.cpp
@@ -128,8 +128,7 @@ std::string const &RPiCamApp::CameraId() const
 
 std::string RPiCamApp::CameraModel() const
 {
-	auto model = camera_->properties().get(properties::Model);
-	return model ? *model : camera_->id();
+	return std::string(camera_->properties().get(properties::Model).value_or(camera_->id()));
 }
 
 void RPiCamApp::OpenCamera()


### PR DESCRIPTION
This is a change to the libcamera API, switch to std::string_view from std::string.