### PR TITLE
Check correctly for protocols that handle their own files

### DIFF
--- a/encoder/libav_encoder.cpp
+++ b/encoder/libav_encoder.cpp
@@ -477,7 +477,7 @@ void LibAvEncoder::initOutput()
 	avcodec_parameters_from_context(stream_[Video]->codecpar, codec_ctx_[Video]);
 
 	char err[64];
-	if (!(out_fmt_ctx_->flags & AVFMT_NOFILE))
+	if (!(out_fmt_ctx_->oformat->flags & AVFMT_NOFILE))
 	{
 		std::string filename = output_file_.empty() ? "/dev/null" : output_file_;
 


### PR DESCRIPTION
Some protocols open their own file handes, so we mustn't try to do this for them as it will fail. The correct way to do this is to check the context's oformat->flags, not the flags field directly.

The reason is that the flags report the current state of the context, whereas oformat->flags reports what this particular output format requires, which is therefore correct.

The consequence is that we can output RTSP streams directly, which is useful for publishing to media servers like MediaMTX using a runOnDemand command.