### PR TITLE
Provide further options to display hailo examples 

### DIFF
--- a/assets/hailo_scrfd.json
+++ b/assets/hailo_scrfd.json
@@ -12,6 +12,10 @@
 
     "hailo_scrfd":
     {
-        "hef_file": "/usr/share/hailo-models/scrfd_2.5g_h8l.hef"
+        "hef_file": "/usr/share/hailo-models/scrfd_2.5g_h8l.hef",
+
+        "display_window_width": 320,
+        "display_window_height": 320,
+        "display_fullscreen": false
     }
 }

--- a/assets/hailo_yolov5_segmentation.json
+++ b/assets/hailo_yolov5_segmentation.json
@@ -18,6 +18,10 @@
         "hef_file_8L": "/usr/share/hailo-models/yolov5n_seg_h8l_mz.hef",
         "hef_file_8": "/usr/share/hailo-models/yolov5n_seg_h8.hef",
         "hef_file_10": "/usr/share/hailo-models/yolov5n_seg_h10.hef",
-        "hailopp_config_file": "/usr/share/hailo-models/yolov5seg.json"
+        "hailopp_config_file": "/usr/share/hailo-models/yolov5seg.json",
+
+        "display_window_width": 320,
+        "display_window_height": 320,
+        "display_fullscreen": false
     }
 }

--- a/assets/hailo_yolov8_pose.json
+++ b/assets/hailo_yolov8_pose.json
@@ -13,6 +13,10 @@
     {
         "hef_file_10": "/usr/share/hailo-models/yolov8m_pose_h10.hef",
         "hef_file_8L": "/usr/share/hailo-models/yolov8s_pose_h8l_pi.hef",
-        "hef_file_8": "/usr/share/hailo-models/yolov8s_pose_h8.hef"
+        "hef_file_8": "/usr/share/hailo-models/yolov8s_pose_h8.hef",
+
+        "display_window_width": 320,
+        "display_window_height": 320,
+        "display_fullscreen": false
     }
 }

--- a/post_processing_stages/hailo/hailo_postprocessing_stage.hpp
+++ b/post_processing_stages/hailo/hailo_postprocessing_stage.hpp
@@ -189,6 +189,10 @@ protected:
 	std::shared_ptr<hailort::ConfiguredInferModel> configured_infer_model_;
 	MessageQueue &msg_queue_;
 
+	int display_window_width_ = 320;
+	int display_window_height_ = 320;
+	bool display_fullscreen_ = false;
+
 private:
 	int configureHailoRT();
 	void displayThread();


### PR DESCRIPTION
With these changes, the size of the windows can be changed (including fullscreen) and for pose detection the additional detection boxes can be disabled. With these changes the capabilities of Hailo on the Raspberry Pi can be demonstrated much better in a live demonstration.