### PR TITLE
postprocess: hailo: Workaround an exception in the hailort library

### DIFF
--- a/post_processing_stages/hailo/hailo_postprocessing_stage.cpp
+++ b/post_processing_stages/hailo/hailo_postprocessing_stage.cpp
@@ -73,7 +73,9 @@ public:
 
 	static VDevice *get_instance()
 	{
-		static std::unique_ptr<VDevice> _vdevice {};
+		// Deliberately leaked to avoid a segfault in libhailort's
+		// VDevice destructor during static destruction at exit.
+		static VDevice *_vdevice = nullptr;
 
 		if (!_vdevice)
 		{
@@ -83,10 +85,10 @@ public:
 				LOG_ERROR("Failed create vdevice, status = " << vdevice_exp.status());
 				return nullptr;
 			}
-			_vdevice = vdevice_exp.release();
+			_vdevice = vdevice_exp.release().release();
 		}
 
-		return _vdevice.get();
+		return _vdevice;
 	}
 
 private:


### PR DESCRIPTION
The Hilao post-processing stage segfaults at process exit due to a static destruction order bug in libhailort. The VDevice singleton is held in a static unique_ptr which gets destroyed during exit() teardown, but by that point other statics inside libhailort that the VDevice destructor depends on have already been destroyed, causing a use-after-free crash in Buffer::~Buffer().

The fix is to intentionally leak the VDevice by storing it as a raw pointer instead of a unique_ptr. The OS reclaims the memory at process exit anyway, and this avoids triggering the buggy libhailort destructor.