### PR TITLE
build: Switch to C++ 20

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project('rpicam-apps', 'c', 'cpp',
         default_options : [
             'werror=true',
             'warning_level=3',
-            'cpp_std=c++17',
+            'cpp_std=c++20',
             'c_std=c11',
             'buildtype=release',
         ],

--- a/post_processing_stages/meson.build
+++ b/post_processing_stages/meson.build
@@ -65,6 +65,8 @@ if opencv_dep.found()
     if cxx.get_id() == 'clang'
         opencv_cpp_args += '-Wno-c11-extensions'
     endif
+    # OpenCV headers trigger deprecated-enum-enum-conversion under C++20.
+    opencv_cpp_args += '-Wno-deprecated-enum-enum-conversion'
 
     opencv_postproc_lib = shared_module('opencv-postproc', opencv_postproc_src,
                                         include_directories : '../',


### PR DESCRIPTION
Also suppress -Wdeprecated-enum-enum-conversion for the opencv-postproc module, as OpenCV 4 headers perform arithmetic between unrelated enum types which becomes a hard error under C++20 with -Werror.