### PR TITLE
object_detect_udp_stage: fix name buffer overread and GCC 12 false positive

### DIFF
--- a/post_processing_stages/object_detect_udp_stage.cpp
+++ b/post_processing_stages/object_detect_udp_stage.cpp
@@ -110,9 +110,12 @@ void ObjectDetectUDPStage::Read(boost::property_tree::ptree const &params)
 // GCC 12 incorrectly reports out-of-bounds memset/-overflow when inlining
 // resize() inside this template for large T (e.g. std::array<uint8_t,255>).
 // The accesses are valid; suppress the false positive.
+// Clang does not know -Wstringop-overflow, so guard with __GNUC__.
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 template <typename T>
 void append(std::vector<char> &buffer, const T &value)
 {
@@ -121,7 +124,9 @@ void append(std::vector<char> &buffer, const T &value)
 	buffer.resize(old_size + sizeof(T));
 	std::memcpy(buffer.data() + old_size, raw, sizeof(T));
 }
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
 
 bool ObjectDetectUDPStage::Process(CompletedRequestPtr &completed_request)
 {

--- a/post_processing_stages/object_detect_udp_stage.cpp
+++ b/post_processing_stages/object_detect_udp_stage.cpp
@@ -107,6 +107,12 @@ void ObjectDetectUDPStage::Read(boost::property_tree::ptree const &params)
 	udp_broadcast_port = params.get<u_int16_t>("port", UDP_PORT);
 }
 
+// GCC 12 incorrectly reports out-of-bounds memset/-overflow when inlining
+// resize() inside this template for large T (e.g. std::array<uint8_t,255>).
+// The accesses are valid; suppress the false positive.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#pragma GCC diagnostic ignored "-Warray-bounds"
 template <typename T>
 void append(std::vector<char> &buffer, const T &value)
 {
@@ -115,6 +121,7 @@ void append(std::vector<char> &buffer, const T &value)
 	buffer.resize(old_size + sizeof(T));
 	std::memcpy(buffer.data() + old_size, raw, sizeof(T));
 }
+#pragma GCC diagnostic pop
 
 bool ObjectDetectUDPStage::Process(CompletedRequestPtr &completed_request)
 {
@@ -155,9 +162,10 @@ bool ObjectDetectUDPStage::Process(CompletedRequestPtr &completed_request)
 		constexpr uint8_t name_length = 255;
 		udp_data_buffer.push_back(static_cast<char>(name_length));
 
-		std::array<uint8_t, name_length> name;
-		memcpy(name.data(), detection.name.c_str(), name_length - 2);
-		name[name_length - 1] = '\0';
+		std::array<uint8_t, name_length> name {};
+		const size_t copy_len = std::min(detection.name.size(), static_cast<size_t>(name_length - 1));
+		memcpy(name.data(), detection.name.c_str(), copy_len);
+		// name[copy_len] is already '\0' from zero-initialisation above.
 		append(udp_data_buffer, name);
 
 		// 4. Add confidence (4 bytes)


### PR DESCRIPTION
## Problem

In `ObjectDetectUDPStage::Process()` the name field of each detection was serialised with a hard-coded `memcpy` of 253 bytes:

```cpp
std::array<uint8_t, name_length> name;
memcpy(name.data(), detection.name.c_str(), name_length - 2);  // always 253 bytes
name[name_length - 1] = '\0';                                   // only byte 254
```

Three bugs:

1. **Buffer overread**: `detection.name` is typically a short label (e.g. `"person"`, 6 bytes). `memcpy` always reads 253 bytes, reading well past the end of the string — undefined behaviour.
2. **Uninitialised bytes**: the array is not zero-initialised, so bytes between `name.size()` and byte 253 contain stack garbage sent over the UDP socket.
3. **GCC 12 false positive**: `append<std::array<uint8_t,255>>` triggers a spurious `-Wstringop-overflow` / `-Warray-bounds` diagnostic from `vector::resize()` inlined deep in `stl_algobase.h`. The access is entirely within bounds; GCC's alias analysis loses track of the allocation origin.

## Fix

- Zero-initialise the array (`name{}`).
- Copy only `min(detection.name.size(), name_length - 1)` bytes.
- The NUL terminator is already present from zero-initialisation; no explicit `name[254] = '\0'` needed.
- Suppress the GCC 12 false positive with a narrow `#pragma GCC diagnostic` pair around the `append` template definition, with a comment explaining the root cause.

The on-wire format is unchanged — the receiver still reads exactly `name_length` (255) bytes for the name field.

## Testing

Compiled with GCC 12.2.0, -O3 -Wall -Wextra -Warray-bounds=2 (OpenCV enabled) — no warnings.