### PR TITLE
preview: egl: Keep titlebar on-screen for default window position

### DIFF
--- a/preview/egl_preview.cpp
+++ b/preview/egl_preview.cpp
@@ -302,7 +302,9 @@ void EglPreview::makeWindow(char const *name)
 		sizehints.y = y_;
 		sizehints.width = width_;
 		sizehints.height = height_;
-		sizehints.flags = USSize | USPosition;
+		sizehints.flags = USSize;
+		if (options_->Get().preview_x || options_->Get().preview_y)
+			sizehints.flags |= USPosition;
 		XSetNormalHints(display_, window_, &sizehints);
 		XSetStandardProperties(display_, window_, name, name, None, (char **)NULL, 0, &sizehints);
 	}


### PR DESCRIPTION
The EGL preview set USPosition unconditionally, instructing the window manager to place the client area exactly at the requested (x, y). When no position was specified the default (0, 0) put the titlebar above the screen edge.

Only set USPosition when the user actually requested a non-zero preview position.