### PR TITLE
Add logging message so that the state of enable_ can be read externally

### DIFF
--- a/output/output.cpp
+++ b/output/output.cpp
@@ -50,6 +50,7 @@ Output::~Output()
 void Output::Signal()
 {
 	enable_ = !enable_;
+	LOG(1, "Output enabled = " << (enable_.load() ? "true" : "false"));
 }
 
 void Output::OutputReady(void *mem, size_t size, int64_t timestamp_us, bool keyframe)


### PR DESCRIPTION
When using the -s flag so that the capture process in rpicam-vid can be paused or restarted I could not find an easy way to determine the paused/recording state of the program short of maintaining my own outside state variable.

This adds a logging statement to the output->Signal function to report the current state of enable_.