### PR TITLE
Enable ZSL mode when writing non-JPEG images

### DIFF
--- a/apps/rpicam_still.cpp
+++ b/apps/rpicam_still.cpp
@@ -205,7 +205,7 @@ static void event_loop(RPiCamStillApp &app)
 		}
 	}
 	else if (options->Get().zsl)
-		app.ConfigureZsl();
+		app.ConfigureZsl(still_flags);
 	else
 		app.ConfigureViewfinder();
 	app.StartCamera();


### PR DESCRIPTION
ZSL mode was always producing YUV420 outputs, which only worked with JPEG. Make it respect the "still" flags like regular still image capture does.